### PR TITLE
adding new methods to export the gateway and erc20 contract on the Ax…

### DIFF
--- a/src/libs/AxelarGateway.ts
+++ b/src/libs/AxelarGateway.ts
@@ -129,7 +129,20 @@ export class AxelarGateway {
     return this.contract.isCommandExecuted(commandId);
   }
 
-  getTokenAddress(symbol: string) {
+  getTokenAddress(symbol: string): Promise<string> {
     return this.contract.tokenAddresses(symbol);
   }
+
+  async getERC20TokenContract(tokenSymbol: string): Promise<ethers.Contract> {
+    return new ethers.Contract(
+      await this.getTokenAddress(tokenSymbol),
+      erc20Abi,
+      this.provider
+    );
+  }
+
+  getContract(): ethers.Contract {
+    return this.contract;
+  }
+
 }


### PR DESCRIPTION
this PR follows up this one: https://github.com/axelarnetwork/axelarjs-sdk/pull/75 after discussion with @npty . 

The simplest way to acommodate this request is to simply export the contract in the AxelarGateway class. And also exported the erc20 contract. So that's what this PR does. 

> based on conversation with Foivos/Kiryl, the desire was to refactor our contract interaction methods so that the AxelarGateway class is itself a contract (just by having the class extend ethers.Contract). 

> The reason to make it contract-based is two-fold:
> * eliminates the two-step process of first creating an unsigned tx, following by sending the tx to the contract.
> * allows these ethers smart contracts to be invoked by other ethers smart contracts in other web3 environments. 

The reason we are keeping the original code in the two-step form is to accommodate some potential apps that may want to allow for gas estimation. 