### PR TITLE
Refactor `execute` function

### DIFF
--- a/src/libs/TransactionRecoveryApi/AxelarGMPRecoveryAPI.ts
+++ b/src/libs/TransactionRecoveryApi/AxelarGMPRecoveryAPI.ts
@@ -298,7 +298,7 @@ export class AxelarGMPRecoveryAPI extends AxelarRecoveryApi {
    * @returns The result of executing the transaction.
    */
   public async execute(srcTxHash: string, evmWalletDetails?: EvmWalletDetails): Promise<TxResult> {
-    const response = await this.queryExecuteParams(srcTxHash);
+    const response = await this.queryExecuteParams(srcTxHash).catch(() => undefined);
     // Couldn't query the transaction details
     if (!response) return GMPQueryError();
     // Already executed

--- a/src/libs/TransactionRecoveryApi/AxelarGMPRecoveryAPI.ts
+++ b/src/libs/TransactionRecoveryApi/AxelarGMPRecoveryAPI.ts
@@ -103,11 +103,25 @@ export class AxelarGMPRecoveryAPI extends AxelarRecoveryApi {
     return await this.processor.process(params);
   }
 
+  /**
+   * Check if given transaction is already executed.
+   * @param txHash string - transaction hash
+   * @returns Promise<boolean> - true if transaction is already executed
+   */
   public async isExecuted(txHash: string): Promise<boolean> {
     const txStatus = await this.queryTransactionStatus(txHash).catch(() => undefined);
     return txStatus?.status === GMPStatus.EXECUTED;
   }
 
+  /**
+   * Calculate the gas fee in native token for executing a transaction at the destination chain using the source chain's gas price.
+   * @param txHash string - transaction hash
+   * @param sourceChain EVMChain - source chain
+   * @param destinationChain EVMChain - destination chain
+   * @param gasTokenSymbol string - gas token symbol
+   * @param options QueryGasFeeOptions - options
+   * @returns Promise<string> - The gas fee to be paid at source chain
+   */
   public async calculateNativeGasFee(
     txHash: string,
     sourceChain: EvmChain,
@@ -122,6 +136,15 @@ export class AxelarGMPRecoveryAPI extends AxelarRecoveryApi {
     return this.subtractGasFee(sourceChain, destinationChain, gasTokenSymbol, paidGasFee, options);
   }
 
+  /**
+   * Calculate the gas fee in an ERC-20 tokens for executing a transaction at the destination chain using the source chain's gas price.
+   * @param txHash string - transaction hash
+   * @param sourceChain EVMChain - source chain
+   * @param destinationChain EVMChain - destination chain
+   * @param gasTokenSymbol string - gas token symbol
+   * @param options QueryGasFeeOptions - options
+   * @returns Promise<string> - The gas fee to be paid at source chain
+   */
   public async calculateGasFee(
     txHash: string,
     sourceChain: EvmChain,
@@ -136,6 +159,14 @@ export class AxelarGMPRecoveryAPI extends AxelarRecoveryApi {
     return this.subtractGasFee(sourceChain, destinationChain, gasTokenSymbol, paidGasFee, options);
   }
 
+  /**
+   * Pay native token as gas fee for the given transaction hash.
+   * If the transaction details is not valid, it will return an error with reason.
+   * @param chain - source chain
+   * @param txHash - transaction hash
+   * @param options - options
+   * @returns
+   */
   public async addNativeGas(
     chain: EvmChain,
     txHash: string,
@@ -192,6 +223,16 @@ export class AxelarGMPRecoveryAPI extends AxelarRecoveryApi {
       .catch(ContractCallError);
   }
 
+  /**
+   * Pay ERC20 token as gas fee for the given transaction hash.
+   * If the transaction details or `gasTokenAddress` is not valid, it will return an error with reason.
+   *
+   * @param chain EvmChain - The source chain of the transaction hash.
+   * @param txHash string - The transaction hash.
+   * @param gasTokenAddress string - The address of the ERC20 token to pay as gas fee.
+   * @param options AddGasOptions - The options to pay gas fee.
+   * @returns
+   */
   public async addGas(
     chain: EvmChain,
     txHash: string,
@@ -257,6 +298,12 @@ export class AxelarGMPRecoveryAPI extends AxelarRecoveryApi {
       .catch(ContractCallError);
   }
 
+  /**
+   * Execute a transaction on the destination chain associated with given `srcTxHash`.
+   * @param srcTxHash - The transaction hash on the source chain.
+   * @param evmWalletDetails - The wallet details to use for executing the transaction.
+   * @returns The result of executing the transaction.
+   */
   public async execute(srcTxHash: string, evmWalletDetails?: EvmWalletDetails): Promise<TxResult> {
     const response = await this.queryExecuteParams(srcTxHash);
     // Couldn't query the transaction details

--- a/src/libs/TransactionRecoveryApi/AxelarGMPRecoveryAPI.ts
+++ b/src/libs/TransactionRecoveryApi/AxelarGMPRecoveryAPI.ts
@@ -15,14 +15,7 @@ import EVMClient from "./client/EVMClient";
 import { broadcastCosmosTxBytes } from "./client/helpers/cosmos";
 import AxelarGMPRecoveryProcessor from "./processors";
 import IAxelarExecutable from "../abi/IAxelarExecutable";
-import {
-  BigNumber,
-  Contract,
-  ContractFunction,
-  ContractReceipt,
-  ContractTransaction,
-  ethers,
-} from "ethers";
+import { ContractReceipt, ContractTransaction, ethers } from "ethers";
 import IAxelarGasService from "../abi/IAxelarGasService.json";
 import { GAS_RECEIVER, NATIVE_GAS_TOKEN_SYMBOL } from "./constants/contract";
 import { AxelarQueryAPI } from "../AxelarQueryAPI";

--- a/src/libs/TransactionRecoveryApi/AxelarGMPRecoveryAPI.ts
+++ b/src/libs/TransactionRecoveryApi/AxelarGMPRecoveryAPI.ts
@@ -283,7 +283,7 @@ export class AxelarGMPRecoveryAPI extends AxelarRecoveryApi {
     const signerAddress = await signer.getAddress();
     const executeTxHash = txResult.transaction?.transactionHash;
     if (executeTxHash) {
-      await this.saveGMP(srcTxHash, executeTxHash, signerAddress).catch();
+      await this.saveGMP(srcTxHash, executeTxHash, signerAddress).catch(() => undefined);
     }
 
     return txResult;

--- a/src/libs/TransactionRecoveryApi/AxelarRecoveryApi.ts
+++ b/src/libs/TransactionRecoveryApi/AxelarRecoveryApi.ts
@@ -25,7 +25,7 @@ export interface GMPStatusResponse {
 
 export interface ExecuteParams {
   commandId: string;
-  sourceChain: EvmChain;
+  sourceChain: string;
   destinationChain: EvmChain;
   sourceAddress: string;
   destinationContractAddress: string;
@@ -131,7 +131,7 @@ export class AxelarRecoveryApi {
         isContractCallWithToken: callTx.event === "ContractCallWithToken",
         payload: callTx.returnValues.payload,
         sourceAddress: approvalTx.returnValues.sourceAddress,
-        sourceChain: callTx.chain.toLowerCase() as EvmChain,
+        sourceChain: approvalTx.returnValues.sourceChain,
         symbol: approvalTx.returnValues.symbol,
         amount:
           approvalTx.returnValues.amount &&

--- a/src/libs/TransactionRecoveryApi/AxelarRecoveryApi.ts
+++ b/src/libs/TransactionRecoveryApi/AxelarRecoveryApi.ts
@@ -133,7 +133,9 @@ export class AxelarRecoveryApi {
         sourceAddress: approvalTx.returnValues.sourceAddress,
         sourceChain: callTx.chain.toLowerCase() as EvmChain,
         symbol: approvalTx.returnValues.symbol,
-        amount: BigNumber.from(approvalTx.returnValues.amount).toString(),
+        amount:
+          approvalTx.returnValues.amount &&
+          BigNumber.from(approvalTx.returnValues.amount).toString(),
       },
     };
   }

--- a/src/libs/TransactionRecoveryApi/AxelarRecoveryApi.ts
+++ b/src/libs/TransactionRecoveryApi/AxelarRecoveryApi.ts
@@ -8,6 +8,7 @@ import { AxelarQueryClient, AxelarQueryClientType } from "../AxelarQueryClient";
 import EVMClient from "./client/EVMClient";
 import { TransactionRequest } from "@ethersproject/providers";
 import { rpcMap } from "./constants/chain";
+import { BigNumber } from "ethers";
 
 export enum GMPStatus {
   CALL = "call",
@@ -20,6 +21,23 @@ export interface GMPStatusResponse {
   status: GMPStatus;
   details: any;
   call: any;
+}
+
+export interface ExecuteParams {
+  commandId: string;
+  sourceChain: EvmChain;
+  destinationChain: EvmChain;
+  sourceAddress: string;
+  destinationContractAddress: string;
+  payload: string;
+  symbol?: string;
+  amount?: string;
+  isContractCallWithToken: boolean;
+}
+
+export interface ExecuteParamsResponse {
+  status: GMPStatus;
+  data?: ExecuteParams;
 }
 
 export class AxelarRecoveryApi {
@@ -76,6 +94,48 @@ export class AxelarRecoveryApi {
         details: "",
         call: res[0]?.call,
       };
+  }
+
+  public async queryExecuteParams(txHash: string): Promise<Nullable<ExecuteParamsResponse>> {
+    const res = await this.execGet(this.axelarCachingServiceUrl, {
+      method: "searchGMP",
+      txHash,
+    });
+    if (!res) return;
+    if (!res[0]) return;
+    const data = res[0];
+
+    // Return if approve tx doesn't not exist
+    const approvalTx = data.approved;
+    if (!approvalTx?.transactionHash) {
+      return {
+        status: GMPStatus.CALL,
+      };
+    }
+
+    // Return if it's already executed
+    const executeTx = data.executed;
+    if (executeTx?.transactionHash) {
+      return {
+        status: GMPStatus.EXECUTED,
+      };
+    }
+    const callTx = data.call;
+
+    return {
+      status: GMPStatus.APPROVED,
+      data: {
+        commandId: approvalTx.returnValues.commandId,
+        destinationChain: approvalTx.chain.toLowerCase() as EvmChain,
+        destinationContractAddress: callTx.returnValues.destinationContractAddress,
+        isContractCallWithToken: callTx.event === "ContractCallWithToken",
+        payload: callTx.returnValues.payload,
+        sourceAddress: approvalTx.returnValues.sourceAddress,
+        sourceChain: callTx.chain.toLowerCase() as EvmChain,
+        symbol: approvalTx.returnValues.symbol,
+        amount: BigNumber.from(approvalTx.returnValues.amount).toString(),
+      },
+    };
   }
 
   public async createPendingTransfers(params: { chain: string }) {

--- a/src/libs/TransactionRecoveryApi/constants/error.ts
+++ b/src/libs/TransactionRecoveryApi/constants/error.ts
@@ -39,3 +39,13 @@ export const UnsupportedGasTokenError = (gasTokenAddress: string) => ({
   success: false,
   error: `Token address ${gasTokenAddress} is not supported`,
 });
+
+export const NotApprovedError = () => ({
+  success: false,
+  error: "Transaction has not approved yet",
+});
+
+export const GMPQueryError = () => ({
+  success: false,
+  error: "Couldn't query the transaction details",
+});

--- a/src/libs/TransactionRecoveryApi/helpers/contractCallHelper.ts
+++ b/src/libs/TransactionRecoveryApi/helpers/contractCallHelper.ts
@@ -1,0 +1,24 @@
+import { Contract, ContractReceipt, ContractTransaction } from "ethers";
+import { ExecuteParams } from "../AxelarRecoveryApi";
+
+export function callExecute(params: ExecuteParams, contract: Contract): Promise<ContractReceipt> {
+  const {
+    commandId,
+    isContractCallWithToken,
+    payload,
+    sourceAddress,
+    sourceChain,
+    amount,
+    symbol,
+  } = params;
+
+  if (isContractCallWithToken) {
+    return contract
+      .executeWithToken(commandId, sourceChain, sourceAddress, payload, symbol, amount)
+      .then((tx: ContractTransaction) => tx.wait());
+  } else {
+    return contract
+      .execute(commandId, sourceChain, sourceAddress, payload)
+      .then((tx: ContractTransaction) => tx.wait());
+  }
+}

--- a/src/libs/TransactionRecoveryApi/helpers/index.ts
+++ b/src/libs/TransactionRecoveryApi/helpers/index.ts
@@ -1,2 +1,4 @@
 export * from "./axelarHelper";
 export * from "./contractEventHelper";
+export * from "./providerHelper";
+export * from "./contractCallHelper";

--- a/src/libs/TransactionRecoveryApi/index.ts
+++ b/src/libs/TransactionRecoveryApi/index.ts
@@ -1,2 +1,3 @@
 export * from "./AxelarDepositRecoveryAPI";
 export * from "./AxelarGMPRecoveryAPI";
+export * from "./constants/error";

--- a/src/libs/test/TransactionRecoveryAPI/AxelarGMPRecoveryAPI.spec.ts
+++ b/src/libs/test/TransactionRecoveryAPI/AxelarGMPRecoveryAPI.spec.ts
@@ -26,6 +26,7 @@ import {
 import { AXELAR_GATEWAY } from "../../AxelarGateway";
 import { GMPStatus } from "../../TransactionRecoveryApi/AxelarRecoveryApi";
 import * as ContractCallHelper from "../../TransactionRecoveryApi/helpers/contractCallHelper";
+import { contractReceiptStub, executeParamsStub } from "../stubs";
 
 describe("AxelarDepositRecoveryAPI", () => {
   const { setLogger } = utils;
@@ -757,34 +758,6 @@ describe("AxelarDepositRecoveryAPI", () => {
     const evmWalletDetails: EvmWalletDetails = {
       privateKey: wallet.privateKey,
     };
-    const mockExecuteParams = {
-      commandId: "0xdfeb4a182f0f1d262e82ed36968eaa636fd52de400c886b05060255c57b32d6f",
-      destinationChain: EvmChain.AVALANCHE,
-      destinationContractAddress: wallet.address,
-      isContractCallWithToken: true,
-      payload: "0x",
-      sourceAddress: wallet.address,
-      sourceChain: EvmChain.FANTOM,
-      amount: "1",
-      symbol: "WAVAX",
-    };
-    const mockContractReceipt: ContractReceipt = {
-      transactionHash: "0x739024d5cae44f63669beb1df9512348c2c4b19caf827de66d74c32fe24ee2a0",
-      blockHash: "0x4f5018f52584d798e6145f6998ea1fc9b7716d89653db25960188f9437189620",
-      from: wallet.address,
-      to: wallet.address,
-      confirmations: 1,
-      gasUsed: BigNumber.from("1"),
-      effectiveGasPrice: BigNumber.from("1"),
-      cumulativeGasUsed: BigNumber.from("1"),
-      logs: [],
-      logsBloom: "",
-      contractAddress: wallet.address,
-      byzantium: true,
-      blockNumber: 1,
-      type: 0,
-      transactionIndex: 1,
-    };
 
     beforeEach(async () => {
       jest.clearAllMocks();
@@ -832,7 +805,7 @@ describe("AxelarDepositRecoveryAPI", () => {
       const mockApi = jest.spyOn(api, "queryExecuteParams");
       mockApi.mockResolvedValueOnce({
         status: GMPStatus.APPROVED,
-        data: mockExecuteParams,
+        data: executeParamsStub(),
       });
 
       // Mock contract call is failed
@@ -860,11 +833,11 @@ describe("AxelarDepositRecoveryAPI", () => {
       const mockApi = jest.spyOn(api, "queryExecuteParams");
       mockApi.mockResolvedValueOnce({
         status: GMPStatus.APPROVED,
-        data: mockExecuteParams,
+        data: executeParamsStub(),
       });
 
       // Mock contract call is successful
-      jest.spyOn(ContractCallHelper, "callExecute").mockResolvedValueOnce(mockContractReceipt);
+      jest.spyOn(ContractCallHelper, "callExecute").mockResolvedValueOnce(contractReceiptStub());
 
       // Mock private saveGMP
       const mockGMPApi = jest.spyOn(AxelarGMPRecoveryAPI.prototype as any, "saveGMP");
@@ -877,7 +850,7 @@ describe("AxelarDepositRecoveryAPI", () => {
 
       expect(response).toEqual({
         success: true,
-        transaction: mockContractReceipt,
+        transaction: contractReceiptStub(),
       });
 
       expect(mockGMPApi).toHaveBeenCalledTimes(1);

--- a/src/libs/test/TransactionRecoveryAPI/AxelarGMPRecoveryAPI.spec.ts
+++ b/src/libs/test/TransactionRecoveryAPI/AxelarGMPRecoveryAPI.spec.ts
@@ -1,7 +1,7 @@
 import { AxelarGMPRecoveryAPI } from "../../TransactionRecoveryApi/AxelarGMPRecoveryAPI";
-import { AddGasOptions, Environment, EvmChain, GasToken } from "../../types";
+import { AddGasOptions, Environment, EvmChain, EvmWalletDetails, GasToken } from "../../types";
 import { createNetwork, utils } from "@axelar-network/axelar-local-dev";
-import { Contract, ContractReceipt, ContractTransaction, ethers, Wallet } from "ethers";
+import { BigNumber, Contract, ContractReceipt, ContractTransaction, ethers, Wallet } from "ethers";
 import { deployContract } from "@axelar-network/axelar-local-dev/dist/utils";
 import DistributionExecutable from "../abi/DistributionExecutable.json";
 import DistributionExecutableWithGasToken from "../abi/DistributionExecutableGasToken.json";
@@ -14,13 +14,18 @@ import { GAS_RECEIVER } from "../../TransactionRecoveryApi/constants/contract";
 import {
   AlreadyExecutedError,
   AlreadyPaidGasFeeError,
+  ContractCallError,
   GasPriceAPIError,
+  GMPQueryError,
   InvalidGasTokenError,
   InvalidTransactionError,
+  NotApprovedError,
   NotGMPTransactionError,
   UnsupportedGasTokenError,
 } from "../../TransactionRecoveryApi/constants/error";
 import { AXELAR_GATEWAY } from "../../AxelarGateway";
+import { GMPStatus } from "../../TransactionRecoveryApi/AxelarRecoveryApi";
+import * as ContractCallHelper from "../../TransactionRecoveryApi/helpers/contractCallHelper";
 
 describe("AxelarDepositRecoveryAPI", () => {
   const { setLogger } = utils;
@@ -743,6 +748,139 @@ describe("AxelarDepositRecoveryAPI", () => {
       expect(args?.logIndex?.toNumber()).toBe(expectedLogIndex);
       expect(eventGasFeeAmount).toBe(expectedGasFee);
       expect(args?.refundAddress).toBe(userWallet.address);
+    });
+  });
+
+  describe("execute", () => {
+    let api: AxelarGMPRecoveryAPI;
+    const wallet = Wallet.createRandom();
+    const evmWalletDetails: EvmWalletDetails = {
+      privateKey: wallet.privateKey,
+    };
+    const mockExecuteParams = {
+      commandId: "0xdfeb4a182f0f1d262e82ed36968eaa636fd52de400c886b05060255c57b32d6f",
+      destinationChain: EvmChain.AVALANCHE,
+      destinationContractAddress: wallet.address,
+      isContractCallWithToken: true,
+      payload: "0x",
+      sourceAddress: wallet.address,
+      sourceChain: EvmChain.FANTOM,
+      amount: "1",
+      symbol: "WAVAX",
+    };
+    const mockContractReceipt: ContractReceipt = {
+      transactionHash: "0x739024d5cae44f63669beb1df9512348c2c4b19caf827de66d74c32fe24ee2a0",
+      blockHash: "0x4f5018f52584d798e6145f6998ea1fc9b7716d89653db25960188f9437189620",
+      from: wallet.address,
+      to: wallet.address,
+      confirmations: 1,
+      gasUsed: BigNumber.from("1"),
+      effectiveGasPrice: BigNumber.from("1"),
+      cumulativeGasUsed: BigNumber.from("1"),
+      logs: [],
+      logsBloom: "",
+      contractAddress: wallet.address,
+      byzantium: true,
+      blockNumber: 1,
+      type: 0,
+      transactionIndex: 1,
+    };
+
+    beforeEach(async () => {
+      jest.clearAllMocks();
+      api = new AxelarGMPRecoveryAPI({ environment: Environment.TESTNET });
+    });
+
+    test("it shouldn't call 'execute' given tx is already executed", async () => {
+      const mockApi = jest.spyOn(api, "queryExecuteParams");
+      mockApi.mockResolvedValueOnce({ status: GMPStatus.EXECUTED });
+
+      const response = await api.execute(
+        "0x86e5f91eff5a8a815e90449ca32e02781508f3b94620bbdf521f2ba07c41d9ae",
+        evmWalletDetails
+      );
+
+      expect(response).toEqual(AlreadyExecutedError());
+    });
+
+    test("it shouldn't call 'execute' given tx has not approved yet", async () => {
+      const mockApi = jest.spyOn(api, "queryExecuteParams");
+      mockApi.mockResolvedValueOnce({ status: GMPStatus.CALL });
+
+      const response = await api.execute(
+        "0x86e5f91eff5a8a815e90449ca32e02781508f3b94620bbdf521f2ba07c41d9ae",
+        evmWalletDetails
+      );
+
+      expect(response).toEqual(NotApprovedError());
+    });
+
+    test("it shouldn't call 'execute' given gmp api error", async () => {
+      const mockApi = jest.spyOn(api, "queryExecuteParams");
+      mockApi.mockResolvedValueOnce(undefined);
+
+      const response = await api.execute(
+        "0x86e5f91eff5a8a815e90449ca32e02781508f3b94620bbdf521f2ba07c41d9ae",
+        evmWalletDetails
+      );
+
+      expect(response).toEqual(GMPQueryError());
+    });
+
+    test("it shouldn't call 'saveGMP' given contract call failed", async () => {
+      // mock query api
+      const mockApi = jest.spyOn(api, "queryExecuteParams");
+      mockApi.mockResolvedValueOnce({
+        status: GMPStatus.APPROVED,
+        data: mockExecuteParams,
+      });
+
+      // Mock contract call is failed
+      const error = new Error("reverted");
+      jest.spyOn(ContractCallHelper, "callExecute").mockRejectedValueOnce(error);
+
+      // Mock private saveGMP
+      const mockGMPApi = jest.spyOn(AxelarGMPRecoveryAPI.prototype as any, "saveGMP");
+      mockGMPApi.mockImplementation(() => Promise.resolve(undefined));
+
+      const response = await api.execute(
+        "0x86e5f91eff5a8a815e90449ca32e02781508f3b94620bbdf521f2ba07c41d9ae",
+        evmWalletDetails
+      );
+
+      // Expect returns error
+      expect(response).toEqual(ContractCallError(error));
+
+      // Expect we don't call saveGMP api
+      expect(mockGMPApi).not.toHaveBeenCalled();
+    });
+
+    test("it should call 'execute' and return success = true", async () => {
+      // mock query api
+      const mockApi = jest.spyOn(api, "queryExecuteParams");
+      mockApi.mockResolvedValueOnce({
+        status: GMPStatus.APPROVED,
+        data: mockExecuteParams,
+      });
+
+      // Mock contract call is successful
+      jest.spyOn(ContractCallHelper, "callExecute").mockResolvedValueOnce(mockContractReceipt);
+
+      // Mock private saveGMP
+      const mockGMPApi = jest.spyOn(AxelarGMPRecoveryAPI.prototype as any, "saveGMP");
+      mockGMPApi.mockImplementation(() => Promise.resolve(undefined));
+
+      const response = await api.execute(
+        "0x86e5f91eff5a8a815e90449ca32e02781508f3b94620bbdf521f2ba07c41d9ae",
+        evmWalletDetails
+      );
+
+      expect(response).toEqual({
+        success: true,
+        transaction: mockContractReceipt,
+      });
+
+      expect(mockGMPApi).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/src/libs/test/TransactionRecoveryAPI/AxelarRecoveryAPI.spec.ts
+++ b/src/libs/test/TransactionRecoveryAPI/AxelarRecoveryAPI.spec.ts
@@ -1,5 +1,6 @@
-import { AxelarRecoveryApi } from "../../TransactionRecoveryApi/AxelarRecoveryApi";
-import { Environment } from "../../types";
+import { ethers } from "hardhat";
+import { AxelarRecoveryApi, GMPStatus } from "../../TransactionRecoveryApi/AxelarRecoveryApi";
+import { Environment, EvmChain } from "../../types";
 
 describe("AxelarDepositRecoveryAPI", () => {
   const api = new AxelarRecoveryApi({ environment: Environment.TESTNET });
@@ -48,5 +49,142 @@ describe("AxelarDepositRecoveryAPI", () => {
       console.log("confirmation", confirmation);
       expect(confirmation).toBeTruthy();
     }, 60000);
+  });
+
+  describe("query execute params", () => {
+    test("It should return null when the response is undefined", async () => {
+      jest.spyOn(api, "execGet").mockResolvedValueOnce(undefined);
+
+      const response = await api.queryExecuteParams("0x");
+
+      expect(response).toBeUndefined();
+    });
+    test("It should return null when response array is empty", async () => {
+      jest.spyOn(api, "execGet").mockResolvedValueOnce([]);
+
+      const response = await api.queryExecuteParams("0x");
+
+      expect(response).toBeUndefined();
+    });
+    test("It should return status: 'call' when the approve transaction hash is undefined", async () => {
+      jest.spyOn(api, "execGet").mockResolvedValueOnce([{}]);
+      const response = await api.queryExecuteParams("0x");
+      expect(response?.status).toBe(GMPStatus.CALL);
+
+      jest.spyOn(api, "execGet").mockResolvedValueOnce([
+        {
+          approved: {},
+        },
+      ]);
+      const response2 = await api.queryExecuteParams("0x");
+      expect(response2?.status).toBe(GMPStatus.CALL);
+    });
+    test("It should return status: 'executed' when the execute transaction hash is defined", async () => {
+      jest.spyOn(api, "execGet").mockResolvedValueOnce([
+        {
+          approved: {
+            transactionHash: "0x",
+          },
+          executed: {
+            transactionHash: "0x",
+          },
+        },
+      ]);
+      const response = await api.queryExecuteParams("0x");
+      expect(response?.status).toBe(GMPStatus.EXECUTED);
+    });
+    test("It should get the execute params when the event type is 'ContractCallWithToken'", async () => {
+      const txHash = "0x1";
+      jest.spyOn(api, "execGet").mockResolvedValueOnce([
+        {
+          call: {
+            chain: "Moonbeam",
+            returnValues: {
+              payload: "payload",
+              destinationContractAddress: "destinationContractAddress",
+            },
+            event: "ContractCallWithToken",
+          },
+          approved: {
+            transactionHash: txHash,
+            chain: "Avalanche",
+            returnValues: {
+              commandId: "0x1",
+              sourceAddress: "0x2",
+              sourceChain: "Moonbeam",
+              symbol: "UST",
+              amount: ethers.BigNumber.from("1"),
+            },
+          },
+        },
+      ]);
+      const executeParams = await api.queryExecuteParams(txHash);
+
+      expect(api.execGet).toHaveBeenCalledWith(api.axelarCachingServiceUrl, {
+        method: "searchGMP",
+        txHash,
+      });
+
+      expect(executeParams).toEqual({
+        status: GMPStatus.APPROVED,
+        data: {
+          commandId: "0x1",
+          destinationChain: EvmChain.AVALANCHE,
+          destinationContractAddress: "destinationContractAddress",
+          isContractCallWithToken: true,
+          payload: "payload",
+          sourceAddress: "0x2",
+          sourceChain: "Moonbeam",
+          symbol: "UST",
+          amount: "1",
+        },
+      });
+    });
+
+    test("It should get the execute params when the event type is 'ContractCall'", async () => {
+      const txHash = "0x1";
+      jest.spyOn(api, "execGet").mockResolvedValueOnce([
+        {
+          call: {
+            chain: "Moonbeam",
+            returnValues: {
+              payload: "payload",
+              destinationContractAddress: "destinationContractAddress",
+            },
+            event: "ContractCall",
+          },
+          approved: {
+            transactionHash: txHash,
+            chain: "Avalanche",
+            returnValues: {
+              commandId: "0x1",
+              sourceAddress: "0x2",
+              sourceChain: "Moonbeam",
+            },
+          },
+        },
+      ]);
+      const executeParams = await api.queryExecuteParams(txHash);
+
+      expect(api.execGet).toHaveBeenCalledWith(api.axelarCachingServiceUrl, {
+        method: "searchGMP",
+        txHash,
+      });
+
+      expect(executeParams).toEqual({
+        status: GMPStatus.APPROVED,
+        data: {
+          commandId: "0x1",
+          destinationChain: EvmChain.AVALANCHE,
+          destinationContractAddress: "destinationContractAddress",
+          isContractCallWithToken: false,
+          payload: "payload",
+          sourceAddress: "0x2",
+          sourceChain: "Moonbeam",
+          symbol: undefined,
+          amount: undefined,
+        },
+      });
+    });
   });
 });

--- a/src/libs/test/TransactionRecoveryAPI/helper/contractCallHelper.spec.ts
+++ b/src/libs/test/TransactionRecoveryAPI/helper/contractCallHelper.spec.ts
@@ -1,0 +1,52 @@
+import { callExecute } from "../../../TransactionRecoveryApi/helpers";
+import { contractReceiptStub, executeParamsStub } from "../../stubs";
+
+describe("contractCallHelper", () => {
+  describe("callContract", () => {
+    let mockWait: jest.Mock<any, any>;
+    const stub = executeParamsStub();
+
+    beforeEach(() => {
+      mockWait = jest.fn().mockResolvedValueOnce(contractReceiptStub());
+    });
+
+    test("it should call 'executeWithToken' given 'isContractCallWithToken' is true", async () => {
+      stub.isContractCallWithToken = true;
+
+      // Mock contract's executeWithTokenFunction
+      const mockExecuteWithToken = jest.fn().mockResolvedValueOnce({ wait: mockWait });
+      const contract: any = { executeWithToken: mockExecuteWithToken };
+
+      await callExecute(stub, contract);
+
+      expect(mockExecuteWithToken).toHaveBeenCalledWith(
+        stub.commandId,
+        stub.sourceChain,
+        stub.sourceAddress,
+        stub.payload,
+        stub.symbol,
+        stub.amount
+      );
+      expect(mockWait).toBeCalledTimes(1);
+    });
+
+    test("it should call 'execute' given 'isContractCallWithToken' is false", async () => {
+      const stub = executeParamsStub();
+
+      // Mock contract's execute function
+      const mockExecute = jest.fn().mockResolvedValueOnce({ wait: mockWait });
+      const contract: any = { execute: mockExecute };
+
+      stub.isContractCallWithToken = false;
+      await callExecute(stub, contract);
+
+      expect(mockExecute).toHaveBeenCalledWith(
+        stub.commandId,
+        stub.sourceChain,
+        stub.sourceAddress,
+        stub.payload
+      );
+      expect(mockWait).toBeCalledTimes(1);
+    });
+  });
+});

--- a/src/libs/test/stubs/index.ts
+++ b/src/libs/test/stubs/index.ts
@@ -1,10 +1,11 @@
+import { BigNumber } from "ethers";
+import { EvmChain } from "../../types";
+
 export const uuidStub = () => "83462f97-63cf-4205-a659-6f54bec623f6";
 
-export const ethAddressStub = () =>
-  "0xF16DfB26e1FEc993E085092563ECFAEaDa7eD7fD";
+export const ethAddressStub = () => "0xF16DfB26e1FEc993E085092563ECFAEaDa7eD7fD";
 
-export const terraAddressStub = () =>
-  "terra1qem4njhac8azalrav7shvp06myhqldpmkk3p0t";
+export const terraAddressStub = () => "terra1qem4njhac8azalrav7shvp06myhqldpmkk3p0t";
 
 export const otcStub = () => ({
   otc: "hr64_XnjNE",
@@ -36,8 +37,7 @@ export const linkEventStub = () => ({
   Type: "link",
   Attributes: {
     asset: "uusd",
-    depositAddress:
-      "axelar1ncj6rh3fxzx6pz35gjc6fva534vqmpsx3pwj8s8uyrqrthrch4asgu5l0p",
+    depositAddress: "axelar1ncj6rh3fxzx6pz35gjc6fva534vqmpsx3pwj8s8uyrqrthrch4asgu5l0p",
     destinationAddress: "0xF16DfB26e1FEc993E085092563ECFAEaDa7eD7fD",
     destinationChain: "Avalanche",
     module: "axelarnet",
@@ -50,3 +50,33 @@ export const linkEventStub = () => ({
 
 export const newRoomIdStub = () =>
   '{"depositAddress":"axelar1ncj6rh3fxzx6pz35gjc6fva534vqmpsx3pwj8s8uyrqrthrch4asgu5l0p","sourceModule":"axelarnet","type":"deposit-confirmation"}';
+
+export const executeParamsStub = () => ({
+  commandId: "0xdfeb4a182f0f1d262e82ed36968eaa636fd52de400c886b05060255c57b32d6f",
+  destinationChain: EvmChain.AVALANCHE,
+  destinationContractAddress: "0xF16DfB26e1FEc993E085092563ECFAEaDa7eD7fD",
+  isContractCallWithToken: true,
+  payload: "0x",
+  sourceAddress: "0xF16DfB26e1FEc993E085092563ECFAEaDa7eD7fD",
+  sourceChain: EvmChain.FANTOM,
+  amount: "1",
+  symbol: "WAVAX",
+});
+
+export const contractReceiptStub = () => ({
+  transactionHash: "0x739024d5cae44f63669beb1df9512348c2c4b19caf827de66d74c32fe24ee2a0",
+  blockHash: "0x4f5018f52584d798e6145f6998ea1fc9b7716d89653db25960188f9437189620",
+  from: "0xF16DfB26e1FEc993E085092563ECFAEaDa7eD7fD",
+  to: "0xF16DfB26e1FEc993E085092563ECFAEaDa7eD7fD",
+  confirmations: 1,
+  gasUsed: BigNumber.from("1"),
+  effectiveGasPrice: BigNumber.from("1"),
+  cumulativeGasUsed: BigNumber.from("1"),
+  logs: [],
+  logsBloom: "",
+  contractAddress: "0xF16DfB26e1FEc993E085092563ECFAEaDa7eD7fD",
+  byzantium: true,
+  blockNumber: 1,
+  type: 0,
+  transactionIndex: 1,
+});

--- a/src/libs/types/index.ts
+++ b/src/libs/types/index.ts
@@ -3,7 +3,7 @@ import { Network } from "@ethersproject/networks";
 import { SigningStargateClientOptions } from "@cosmjs/stargate";
 import { OfflineSigner } from "@cosmjs/proto-signing";
 import { LogDescription } from "ethers/lib/utils";
-import { ContractReceipt, ethers, Transaction } from "ethers";
+import { ContractReceipt, ethers } from "ethers";
 
 export enum Environment {
   DEVNET = "devnet",


### PR DESCRIPTION
# Descriptions

Add `execute` function with tests.

Note: the base branch is `feat/addGas` for now, once https://github.com/axelarnetwork/axelarjs-sdk/pull/98 is merged, i will rebase to new alpha version branch.

## Tests

`yarn test -t "callContract" contractCallHelper.spec.ts`

![image](https://user-images.githubusercontent.com/78221556/175548383-7b0fd666-9f63-4757-b8d1-e8fb5412e9a7.png)

`yarn test -t "execute" AxelarGMPRecoveryAPI.spec.ts`

![image](https://user-images.githubusercontent.com/78221556/175548305-39001aaa-7c50-4263-956c-c472c43a10f0.png)

TODO: 
- [ ] Add tests for `queryExecuteParams` function