### PR TITLE
Change GITHUB_TOKEN

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
       - name: "Automated Version Bump"
         id: version-bump
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN_ACTION_BUMP_VERSION }}
         uses: "phips28/gh-action-bump-version@master"
         with:
           tag-prefix: "v"


### PR DESCRIPTION
After enabled branch protection rule, the automate bump version gh action won't be able to push to main branch anymore.

Change the default `GITHUB_TOKEN` to my personal access token, should allow it to be able to push again.

![image](https://user-images.githubusercontent.com/78221556/181260287-2060883f-f3bf-43b5-b804-f9420154a854.png)

Here's all the permission this token has:

![image](https://user-images.githubusercontent.com/78221556/181260536-952ded7f-c660-4d55-ac21-f614bfd0351a.png)
