### PR TITLE
chore: files to exclude to optimize bundle size

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,9 @@
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
   "files": [
-    "dist"
+    "dist",
+    "!dist/src/libs/test",
+    "!dist/test"
   ],
   "scripts": {
     "build": "rimraf dist && tsc",


### PR DESCRIPTION
files to exclude to optimize bundle size. closes #116 