### PR TITLE
Optimize testing time for 'AxelarGMPRecoverAPI'

### DIFF
--- a/src/libs/test/TransactionRecoveryAPI/AxelarGMPRecoveryAPI.spec.ts
+++ b/src/libs/test/TransactionRecoveryAPI/AxelarGMPRecoveryAPI.spec.ts
@@ -60,7 +60,7 @@ describe("AxelarDepositRecoveryAPI", () => {
     }, 60000);
   });
 
-  xdescribe("approveGatewayTx", () => {
+  xdescribe("manualRelayToDestChain", () => {
     const api = new AxelarGMPRecoveryAPI({ environment: Environment.TESTNET });
 
     beforeEach(() => {
@@ -112,7 +112,7 @@ describe("AxelarDepositRecoveryAPI", () => {
       mockSignCommandTx.mockResolvedValueOnce(signCommandStub);
 
       const mockQueryBatchedCommand = jest.spyOn(api, "queryBatchedCommands");
-      mockQueryBatchedCommand.mockResolvedValueOnce(batchedCommandResponseStub());
+      mockQueryBatchedCommand.mockResolvedValue(batchedCommandResponseStub());
 
       const response = await api.manualRelayToDestChain("0x");
 
@@ -266,7 +266,7 @@ describe("AxelarDepositRecoveryAPI", () => {
     });
   });
 
-  describe("calculateWantedGasFee", () => {
+  xdescribe("calculateNativeGasFee", () => {
     const api = new AxelarGMPRecoveryAPI({ environment: Environment.TESTNET });
 
     let contract: Contract;

--- a/src/libs/test/TransactionRecoveryAPI/AxelarGMPRecoveryAPI.spec.ts
+++ b/src/libs/test/TransactionRecoveryAPI/AxelarGMPRecoveryAPI.spec.ts
@@ -60,7 +60,7 @@ describe("AxelarDepositRecoveryAPI", () => {
     }, 60000);
   });
 
-  xdescribe("manualRelayToDestChain", () => {
+  describe("manualRelayToDestChain", () => {
     const api = new AxelarGMPRecoveryAPI({ environment: Environment.TESTNET });
 
     beforeEach(() => {
@@ -266,7 +266,7 @@ describe("AxelarDepositRecoveryAPI", () => {
     });
   });
 
-  xdescribe("calculateNativeGasFee", () => {
+  describe("calculateNativeGasFee", () => {
     const api = new AxelarGMPRecoveryAPI({ environment: Environment.TESTNET });
 
     let contract: Contract;
@@ -367,7 +367,7 @@ describe("AxelarDepositRecoveryAPI", () => {
     });
   });
 
-  xdescribe("addNativeGas", () => {
+  describe("addNativeGas", () => {
     let api: AxelarGMPRecoveryAPI;
     let contract: Contract;
     let userWallet: Wallet;
@@ -668,7 +668,7 @@ describe("AxelarDepositRecoveryAPI", () => {
     });
   });
 
-  xdescribe("addGas", () => {
+  describe("addGas", () => {
     let api: AxelarGMPRecoveryAPI;
     let contract: Contract;
     let userWallet: Wallet;
@@ -1025,7 +1025,7 @@ describe("AxelarDepositRecoveryAPI", () => {
     });
   });
 
-  xdescribe("execute", () => {
+  describe("execute", () => {
     let api: AxelarGMPRecoveryAPI;
     const wallet = Wallet.createRandom();
     const evmWalletDetails: EvmWalletDetails = {
@@ -1192,7 +1192,7 @@ describe("AxelarDepositRecoveryAPI", () => {
       expect(mockGMPApi).toHaveBeenCalledTimes(1);
     });
   });
-  xdescribe("getGasReceiverContractAddress", () => {
+  describe("getGasReceiverContractAddress", () => {
     let api: AxelarGMPRecoveryAPI;
 
     beforeEach(async () => {

--- a/src/libs/test/TransactionRecoveryAPI/AxelarGMPRecoveryAPI.spec.ts
+++ b/src/libs/test/TransactionRecoveryAPI/AxelarGMPRecoveryAPI.spec.ts
@@ -510,6 +510,7 @@ describe("AxelarDepositRecoveryAPI", () => {
         )
         .then((tx: ContractTransaction) => tx.wait());
       jest.spyOn(api, "isExecuted").mockReturnValueOnce(Promise.resolve(false));
+      jest.spyOn(api.axelarQueryApi, "estimateGasFee").mockResolvedValueOnce(gasPaid.toString());
 
       // Call addNativeGas function
       const response = await api.addNativeGas(chain, tx.transactionHash, addNativeGasOptions);


### PR DESCRIPTION
# Description

This PR minimizes the lengthy testing time in `AxelarGMPRecoveryAPI` by mocking the API calls.

# Result
As a result of the optimization, the testing time in `AxelarGMPRecoveryAPI` is decreased from `3m 54s` to `31s`.

Testing on Macbook M1.
| Before                                                                                                          	| After                                                                                                           	|
|-----------------------------------------------------------------------------------------------------------------	|-----------------------------------------------------------------------------------------------------------------	|
| ![image](https://user-images.githubusercontent.com/78221556/188408733-9d35ebee-32b1-4205-9930-75bbd2d361b7.png) 	| ![image](https://user-images.githubusercontent.com/78221556/188407679-8f3df4a3-381e-413c-9b24-e8fa6cc92d2d.png) 	|