### PR TITLE
chore: adding changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [0.11.4] - 2022-SEPTEMBER-22
+
+- update `queryTransactionStatus` in `AxelarRecoveryApi` to include new `executing` status.
+- update GET requests in `AxelarRecoveryApi` to disable cache.
+- fixed a regression issue caused in 0.11.0 in `AxelarAssetTransfer`, where the `getDepositAddress` method is no longer able to generate deposit addresses for cosmos-based destination chains, e.g. Axelar, Osmosis. Please update to this version if you are using this method.
+- [technical fix]: improving error messaging of REST responses.
+
 ## [0.11.3] - 2022-SEPTEMBER-21
 
 - fixed a regression issue caused in 0.11.0 in `AxelarAssetTransfer`, where the `getDepositAddress` method is no longer able to generate deposit addresses for cosmos-based source chains, e.g. Axelar, Osmosis. Please update to this version if you are using this method.

--- a/src/libs/TransactionRecoveryApi/AxelarRecoveryApi.ts
+++ b/src/libs/TransactionRecoveryApi/AxelarRecoveryApi.ts
@@ -295,7 +295,7 @@ export class AxelarRecoveryApi {
     return await fetch(base + "?" + new URLSearchParams(params).toString(), {
       method: "GET",
       headers: { "Content-Type": "application/json" },
-      cache: "no-store"
+      cache: "no-store",
     })
       .then((res) => res.json())
       .then((res) => res.data);

--- a/src/libs/test/TransactionRecoveryAPI/AxelarRecoveryAPI.spec.ts
+++ b/src/libs/test/TransactionRecoveryAPI/AxelarRecoveryAPI.spec.ts
@@ -50,6 +50,42 @@ describe("AxelarDepositRecoveryAPI", () => {
       });
     });
 
+    test("it should return 'GMPStatus.DEST_EXECUTING' when the transaction is still in process", async () => {
+      const txHash = "0x123456789";
+      const txDetails = {
+        call: {
+          transactionHash: txHash,
+        },
+        gas_paid: {
+          transactionHash: txHash,
+        },
+        approved: {
+          transactionHash: txHash + "1",
+        },
+        executed: {
+          transactionHash: txHash + "2",
+        },
+        gas_status: "gas_paid",
+        status: "executing",
+      };
+
+      jest.spyOn(api, "fetchGMPTransaction").mockResolvedValueOnce(txDetails);
+
+      const status = await api.queryTransactionStatus(txHash);
+
+      expect(status).toEqual({
+        status: GMPStatus.DEST_EXECUTING,
+        error: undefined,
+        callTx: txDetails.call,
+        gasPaidInfo: {
+          status: GasPaidStatus.GAS_PAID,
+          details: txDetails.gas_paid,
+        },
+        executed: txDetails.executed,
+        callback: undefined,
+      });
+    });
+
     test("it should return 'GMPStatus.DEST_EXECUTED' when the transaction is already executed", async () => {
       const txHash = "0x123456789";
       const txDetails = {

--- a/src/services/RestService.ts
+++ b/src/services/RestService.ts
@@ -35,11 +35,19 @@ export class RestService {
         return response;
       })
       .then((response) => response.json())
-      .catch((err) => {
+      .catch(async (err) => {
+        let msg;
+
+        try {
+          msg = await err.json();
+        } catch (_) {
+          msg = await err.text();
+        }
+
         throw {
           message: "AxelarJS-SDK uncaught post error",
           uncaught: true,
-          fullMessage: err?.message || err,
+          fullMessage: msg?.message || msg,
         };
       });
   }

--- a/src/services/SocketService.ts
+++ b/src/services/SocketService.ts
@@ -65,6 +65,9 @@ export class SocketService {
         const sourceChainConfig: ChainInfo = this.supportedChains.find(
           (chain) => chain.chainName.toLowerCase() === sourceChain.toLowerCase()
         ) as ChainInfo;
+        const destChainConfig: ChainInfo = this.supportedChains.find(
+          (chain) => chain.chainName.toLowerCase() === destinationChain.toLowerCase()
+        ) as ChainInfo;
         const sourceChainIsAxelarnet = sourceChainConfig?.module === "axelarnet";
         const destChainIsAxelar = destinationChain.toLowerCase() === "axelar";
         const sourceChainMatch =
@@ -72,7 +75,7 @@ export class SocketService {
           attributes.sourceChain.toLowerCase() === sourceChain.toLowerCase();
         const destChainMatch =
           attributes.destinationChain.toLowerCase() ===
-          (destChainIsAxelar ? "axelarnet" : destinationChain.toLowerCase());
+          (destChainIsAxelar ? "axelarnet" : destChainConfig.chainIdentifier[this.environment]);
         const destAddressMatch = attributes.destinationAddress === destinationAddress;
 
         if (sourceChainMatch && destChainMatch && destAddressMatch) {

--- a/test/integration/app.integration-spec.ts
+++ b/test/integration/app.integration-spec.ts
@@ -1,3 +1,5 @@
-import { depositAddressSource } from "./parts/01.deposit-address.spec";
+import { depositAddressSingle } from "./parts/00.deposit-address-single.spec";
+// import { depositAddressSource } from "./parts/01.deposit-address.spec";
 
-depositAddressSource();
+depositAddressSingle();
+// depositAddressSource();

--- a/test/integration/parts/00.deposit-address-single.spec.ts
+++ b/test/integration/parts/00.deposit-address-single.spec.ts
@@ -1,0 +1,34 @@
+import { AxelarAssetTransfer, Environment } from "../../../src";
+
+/**
+ * This test helps to check that a unique deposit address is generated for parallel requests
+ * if the source chain is different but that the destination chain is the same
+ */
+export const depositAddressSingle = () => {
+  jest.setTimeout(60000);
+  const axelarAssetTransfer = new AxelarAssetTransfer({
+    environment: Environment.TESTNET,
+  });
+
+  test("bootstrap", () => {
+    expect(axelarAssetTransfer).toBeDefined();
+  });
+
+  describe("deposit address generation", () => {
+    let result: string;
+
+    beforeAll(async () => {
+      result = await axelarAssetTransfer.getDepositAddress(
+        "avalanche",
+        "moonbeam",
+        "0xB8Cd93C83A974649D76B1c19f311f639e62272BC",
+        "uausdc"
+      );
+    });
+
+    it("should generate unique deposit addresses", () => {
+      expect(typeof result).toBe("string");
+      expect(result.length).toBeGreaterThan(1);
+    });
+  });
+};

--- a/test/integration/parts/01.deposit-address.spec.ts
+++ b/test/integration/parts/01.deposit-address.spec.ts
@@ -6,11 +6,17 @@ import { AxelarAssetTransfer, Environment } from "../../../src";
  */
 export const depositAddressSource = () => {
   jest.setTimeout(60000);
-  const axelarAssetTransferTestnet = new AxelarAssetTransfer({
-    environment: Environment.TESTNET,
-  });
-  const axelarAssetTransferMainnet = new AxelarAssetTransfer({
-    environment: Environment.MAINNET,
+  let axelarAssetTransferTestnet: any;
+  let axelarAssetTransferMainnet: any;
+
+  beforeAll(() => {
+    axelarAssetTransferTestnet= new AxelarAssetTransfer({
+      environment: Environment.TESTNET,
+    });
+    axelarAssetTransferMainnet = new AxelarAssetTransfer({
+      environment: Environment.MAINNET,
+    });
+
   });
 
   test("bootstrap", () => {
@@ -44,12 +50,18 @@ export const depositAddressSource = () => {
           "0xB8Cd93C83A974649D76B1c19f311f639e62272BC",
           "uausdc"
         ),
+        axelarAssetTransferTestnet.getDepositAddress(
+          "moonbeam",
+          "osmosis",
+          "osmo1x3z2vepjd7fhe30epncxjrk0lehq7xdqe8ltsn",
+          "uausdc"
+        ),
       ]);
-      expect(results.length).toBe(4);
+      expect(results.length).toBe(5);
       expect(results[0]).not.toEqual(results[1]);
     });
 
-    it("should be able to generate deposit addresses when the source chain is cosmos-based chain", async () => {
+    xit("should be able to generate deposit addresses when the source chain is cosmos-based chain", async () => {
       const results = await Promise.all([
         axelarAssetTransferMainnet.getDepositAddress(
           "terra",

--- a/test/integration/parts/01.deposit-address.spec.ts
+++ b/test/integration/parts/01.deposit-address.spec.ts
@@ -10,13 +10,12 @@ export const depositAddressSource = () => {
   let axelarAssetTransferMainnet: any;
 
   beforeAll(() => {
-    axelarAssetTransferTestnet= new AxelarAssetTransfer({
+    axelarAssetTransferTestnet = new AxelarAssetTransfer({
       environment: Environment.TESTNET,
     });
     axelarAssetTransferMainnet = new AxelarAssetTransfer({
       environment: Environment.MAINNET,
     });
-
   });
 
   test("bootstrap", () => {


### PR DESCRIPTION
* update queryTransactionStatus in AxelarRecoveryApi to include new executing status.
* update GET requests in AxelarRecoveryApi to disable cache.
* fixed a regression issue caused in 0.11.0 in AxelarAssetTransfer, where the getDepositAddress method is no longer able to generate deposit addresses for cosmos-based destination chains, e.g. Axelar, Osmosis. Please update to this version if you are using this method.
* [technical fix]: improving error messaging of REST responses.