### PR TITLE
Implement getActiveChains query and more

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [0.12.0] - 2022-NOVEMBER-[]
 
-- changing all method signatures to require chain IDs (as recognized by Axelar) instead of chain name. For example, in testnet, Ethereums (Goerli) is recognized as `ethereum-2`
+- changed all method signatures to require chain IDs (as recognized by Axelar) instead of chain name. For example, in testnet, Ethereums (Goerli) is recognized as `ethereum-2`
+- added a query to retrieve all active chains on the network (`getActiveChain`) and updates all method implementations to ensure that invocations are only made to live chains
 - `getDepositAddress` updates:
   1. update payload signature to accept a destructured object parameter. the method is still backwards compatible for previous invocations using regular parameters
   2. merged `getDepositAddressForNativeUnwrap` and `getDepositAddressForNativeWrap` method functionality into `getDepositAddress` method
 - upgrade axelarjs-types dependency to `v0.27.0`
-- update axelar rpc & lcd
+- update default axelar rpc & lcd endpoints in testnet/mainnet from quickapi to imperator
 - fix [native gas estimates](https://github.com/axelarnetwork/axelarjs-sdk/pull/193)
 
 ## [0.11.7] - 2022-OCTOBER-26

--- a/src/libs/AxelarAssetTransfer.ts
+++ b/src/libs/AxelarAssetTransfer.ts
@@ -16,7 +16,7 @@ import {
   validateChainIdentifier,
   validateDestinationAddressByChainName,
 } from "../utils";
-import { getConfigs } from "../constants";
+import { EnvironmentConfigs, getConfigs } from "../constants";
 import { AxelarAssetTransferConfig, Environment, GasToken, isNativeToken } from "./types";
 import DepositReceiver from "../../artifacts/contracts/deposit-service/DepositReceiver.sol/DepositReceiver.json";
 import ReceiverImplementation from "../../artifacts/contracts/deposit-service/ReceiverImplementation.sol/ReceiverImplementation.json";
@@ -25,6 +25,7 @@ import s3 from "./TransactionRecoveryApi/constants/s3";
 import { constants } from "ethers";
 import { ChainInfo } from "../chains/types";
 import { loadChains } from "../chains";
+import { AxelarQueryAPI } from "./AxelarQueryAPI";
 const { HashZero } = constants;
 
 interface GetDepositAddressParams {
@@ -45,6 +46,7 @@ export class AxelarAssetTransfer {
 
   readonly api: RestService;
   readonly depositServiceApi: RestService;
+  readonly axelarQueryApi: AxelarQueryAPI;
   private gasReceiverContract: Record<string, string> = {};
   private depositServiceContract: Record<string, string> = {};
   private evmDenomMap: Record<string, string> = {};
@@ -61,6 +63,13 @@ export class AxelarAssetTransfer {
 
     this.api = new RestService(this.resourceUrl);
     this.depositServiceApi = new RestService(configs.depositServiceUrl);
+
+    const links: EnvironmentConfigs = getConfigs(config.environment);
+    this.axelarQueryApi = new AxelarQueryAPI({
+      environment: config.environment,
+      axelarRpcUrl: links.axelarRpcUrl,
+      axelarLcdUrl: links.axelarLcdUrl,
+    });
   }
 
   async getDepositAddressForNativeWrap(
@@ -71,6 +80,8 @@ export class AxelarAssetTransfer {
   ): Promise<string> {
     await throwIfInvalidChainId(fromChain, this.environment);
     await throwIfInvalidChainId(toChain, this.environment);
+    await this.axelarQueryApi.throwIfInactiveChain(fromChain);
+    await this.axelarQueryApi.throwIfInactiveChain(toChain);
 
     refundAddress = refundAddress || (await this.getGasReceiverContractAddress(fromChain));
     const { address } = await this.getDepositAddressFromRemote(
@@ -104,6 +115,8 @@ export class AxelarAssetTransfer {
   ): Promise<string> {
     await throwIfInvalidChainId(fromChain, this.environment);
     await throwIfInvalidChainId(toChain, this.environment);
+    await this.axelarQueryApi.throwIfInactiveChain(fromChain);
+    await this.axelarQueryApi.throwIfInactiveChain(toChain);
 
     refundAddress = refundAddress || (await this.getGasReceiverContractAddress(fromChain));
 
@@ -148,8 +161,15 @@ export class AxelarAssetTransfer {
   ): Promise<{ address: string }> {
     const endpoint = wrapOrUnWrap === "wrap" ? "/deposit/wrap" : "/deposit/unwrap";
 
-    if (fromChain) await throwIfInvalidChainId(fromChain, this.environment);
-    if (toChain) await throwIfInvalidChainId(toChain, this.environment);
+    if (fromChain) {
+      await throwIfInvalidChainId(fromChain, this.environment);
+      await this.axelarQueryApi.throwIfInactiveChain(fromChain);
+    }
+
+    if (toChain) {
+      await throwIfInvalidChainId(toChain, this.environment);
+      await this.axelarQueryApi.throwIfInactiveChain(toChain);
+    }
 
     return this.depositServiceApi
       .post(endpoint, {
@@ -173,6 +193,9 @@ export class AxelarAssetTransfer {
   ) {
     await throwIfInvalidChainId(fromChain, this.environment);
     await throwIfInvalidChainId(toChain, this.environment);
+    await this.axelarQueryApi.throwIfInactiveChain(fromChain);
+    await this.axelarQueryApi.throwIfInactiveChain(toChain);
+
     const receiverInterface = new Interface(ReceiverImplementation.abi);
     const functionData =
       wrapOrUnWrap === "wrap"
@@ -327,6 +350,8 @@ export class AxelarAssetTransfer {
 
     await throwIfInvalidChainId(fromChain, this.environment);
     await throwIfInvalidChainId(toChain, this.environment);
+    await this.axelarQueryApi.throwIfInactiveChain(fromChain);
+    await this.axelarQueryApi.throwIfInactiveChain(toChain);
 
     const payload = {
       fromChain,
@@ -356,6 +381,8 @@ export class AxelarAssetTransfer {
   ): Promise<string> {
     await throwIfInvalidChainId(sourceChain, this.environment);
     await throwIfInvalidChainId(destinationChain, this.environment);
+    await this.axelarQueryApi.throwIfInactiveChain(sourceChain);
+    await this.axelarQueryApi.throwIfInactiveChain(destinationChain);
     const { newRoomId } = await this.getSocketService()
       .joinRoomAndWaitForEvent(roomId, sourceChain, destinationChain, destinationAddress)
       .catch((error) => {

--- a/src/libs/AxelarAssetTransfer.ts
+++ b/src/libs/AxelarAssetTransfer.ts
@@ -12,7 +12,7 @@ import { CLIENT_API_GET_OTC, CLIENT_API_POST_TRANSFER_ASSET, OTC } from "../serv
 import { RestService, SocketService } from "../services";
 import {
   createWallet,
-  isValidChainIdentifier,
+  throwIfInvalidChainId,
   validateChainIdentifier,
   validateDestinationAddressByChainName,
 } from "../utils";
@@ -69,8 +69,8 @@ export class AxelarAssetTransfer {
     destinationAddress: string,
     refundAddress?: string
   ): Promise<string> {
-    await isValidChainIdentifier(fromChain, this.environment);
-    await isValidChainIdentifier(toChain, this.environment);
+    await throwIfInvalidChainId(fromChain, this.environment);
+    await throwIfInvalidChainId(toChain, this.environment);
 
     refundAddress = refundAddress || (await this.getGasReceiverContractAddress(fromChain));
     const { address } = await this.getDepositAddressFromRemote(
@@ -102,8 +102,8 @@ export class AxelarAssetTransfer {
     destinationAddress: string,
     refundAddress?: string
   ): Promise<string> {
-    await isValidChainIdentifier(fromChain, this.environment);
-    await isValidChainIdentifier(toChain, this.environment);
+    await throwIfInvalidChainId(fromChain, this.environment);
+    await throwIfInvalidChainId(toChain, this.environment);
 
     refundAddress = refundAddress || (await this.getGasReceiverContractAddress(fromChain));
 
@@ -148,8 +148,8 @@ export class AxelarAssetTransfer {
   ): Promise<{ address: string }> {
     const endpoint = wrapOrUnWrap === "wrap" ? "/deposit/wrap" : "/deposit/unwrap";
 
-    if (fromChain) await isValidChainIdentifier(fromChain, this.environment);
-    if (toChain) await isValidChainIdentifier(toChain, this.environment);
+    if (fromChain) await throwIfInvalidChainId(fromChain, this.environment);
+    if (toChain) await throwIfInvalidChainId(toChain, this.environment);
 
     return this.depositServiceApi
       .post(endpoint, {
@@ -171,8 +171,8 @@ export class AxelarAssetTransfer {
     refundAddress: string,
     hexSalt: string
   ) {
-    await isValidChainIdentifier(fromChain, this.environment);
-    await isValidChainIdentifier(toChain, this.environment);
+    await throwIfInvalidChainId(fromChain, this.environment);
+    await throwIfInvalidChainId(toChain, this.environment);
     const receiverInterface = new Interface(ReceiverImplementation.abi);
     const functionData =
       wrapOrUnWrap === "wrap"
@@ -325,8 +325,8 @@ export class AxelarAssetTransfer {
   ): Promise<string> {
     type RoomIdResponse = Record<"data", Record<"roomId", string>>;
 
-    await isValidChainIdentifier(fromChain, this.environment);
-    await isValidChainIdentifier(toChain, this.environment);
+    await throwIfInvalidChainId(fromChain, this.environment);
+    await throwIfInvalidChainId(toChain, this.environment);
 
     const payload = {
       fromChain,
@@ -354,8 +354,8 @@ export class AxelarAssetTransfer {
     destinationChain: string,
     destinationAddress: string
   ): Promise<string> {
-    await isValidChainIdentifier(sourceChain, this.environment);
-    await isValidChainIdentifier(destinationChain, this.environment);
+    await throwIfInvalidChainId(sourceChain, this.environment);
+    await throwIfInvalidChainId(destinationChain, this.environment);
     const { newRoomId } = await this.getSocketService()
       .joinRoomAndWaitForEvent(roomId, sourceChain, destinationChain, destinationAddress)
       .catch((error) => {

--- a/src/libs/AxelarQueryAPI.ts
+++ b/src/libs/AxelarQueryAPI.ts
@@ -247,7 +247,7 @@ export class AxelarQueryAPI {
 
     return this.axelarQueryClient.nexus
       .Chains({ status: ChainStatus.CHAIN_STATUS_ACTIVATED })
-      .then((resp) => resp.chains);
+      .then((resp) => resp.chains.map((chain) => chain.toLowerCase()));
   }
 
   /**

--- a/src/libs/AxelarQueryAPI.ts
+++ b/src/libs/AxelarQueryAPI.ts
@@ -11,7 +11,7 @@ import {
   FeeInfoResponse,
   TransferFeeResponse,
 } from "@axelar-network/axelarjs-types/axelar/nexus/v1beta1/query";
-import { isValidChainIdentifier, validateChainIdentifier } from "../utils";
+import { throwIfInvalidChainId, validateChainIdentifier } from "../utils";
 
 export class AxelarQueryAPI {
   readonly environment: Environment;
@@ -126,8 +126,8 @@ export class AxelarQueryAPI {
     destinationChainId: EvmChain | string,
     sourceTokenSymbol?: GasToken
   ): Promise<BaseFeeResponse> {
-    await isValidChainIdentifier(sourceChainId, this.environment);
-    await isValidChainIdentifier(destinationChainId, this.environment);
+    await throwIfInvalidChainId(sourceChainId, this.environment);
+    await throwIfInvalidChainId(destinationChainId, this.environment);
     await this.throwIfInactiveChain(sourceChainId);
     await this.throwIfInactiveChain(destinationChainId);
     return this.axelarGMPServiceApi
@@ -162,8 +162,8 @@ export class AxelarQueryAPI {
     gasLimit: number = DEFAULT_ESTIMATED_GAS,
     gasMultiplier = 1.1
   ): Promise<string> {
-    await isValidChainIdentifier(sourceChainId, this.environment);
-    await isValidChainIdentifier(destinationChainId, this.environment);
+    await throwIfInvalidChainId(sourceChainId, this.environment);
+    await throwIfInvalidChainId(destinationChainId, this.environment);
     await this.throwIfInactiveChain(sourceChainId);
     await this.throwIfInactiveChain(destinationChainId);
 

--- a/src/libs/AxelarQueryAPI.ts
+++ b/src/libs/AxelarQueryAPI.ts
@@ -164,8 +164,6 @@ export class AxelarQueryAPI {
   ): Promise<string> {
     await throwIfInvalidChainId(sourceChainId, this.environment);
     await throwIfInvalidChainId(destinationChainId, this.environment);
-    await this.throwIfInactiveChain(sourceChainId);
-    await this.throwIfInactiveChain(destinationChainId);
 
     const response = await this.getNativeGasBaseFee(
       sourceChainId,

--- a/src/libs/AxelarQueryAPI.ts
+++ b/src/libs/AxelarQueryAPI.ts
@@ -259,7 +259,7 @@ export class AxelarQueryAPI {
    * @returns true if the chain is active, false otherwise
    */
   public async isChainActive(chainId: EvmChain | string): Promise<boolean> {
-    return this.getActiveChains().then((chains) => chains.includes(chainId));
+    return this.getActiveChains().then((chains) => chains.includes(chainId.toLowerCase()));
   }
 
   /**

--- a/src/libs/AxelarQueryAPI.ts
+++ b/src/libs/AxelarQueryAPI.ts
@@ -250,7 +250,7 @@ export class AxelarQueryAPI {
 
     return this.axelarQueryClient.nexus
       .Chains({ status: ChainStatus.CHAIN_STATUS_ACTIVATED })
-      .then((resp) => resp.chains.map((chain) => chain.toLowerCase()));
+      .then((resp) => resp.chains);
   }
 
   /**
@@ -259,7 +259,9 @@ export class AxelarQueryAPI {
    * @returns true if the chain is active, false otherwise
    */
   public async isChainActive(chainId: EvmChain | string): Promise<boolean> {
-    return this.getActiveChains().then((chains) => chains.includes(chainId.toLowerCase()));
+    return this.getActiveChains()
+      .then((chains) => chains.map((chain) => chain.toLowerCase()))
+      .then((chains) => chains.includes(chainId.toLowerCase()));
   }
 
   /**

--- a/src/libs/TransactionRecoveryApi/AxelarDepositRecoveryAPI.ts
+++ b/src/libs/TransactionRecoveryApi/AxelarDepositRecoveryAPI.ts
@@ -8,7 +8,7 @@ import {
   parseConfirmDepositCosmosResponse,
   parseConfirmDepositEvmResponse,
 } from "./helpers/axelarHelper";
-import { isValidChainIdentifier } from "../../utils";
+import { throwIfInvalidChainId } from "../../utils";
 
 export class AxelarDepositRecoveryAPI extends AxelarRecoveryApi {
   public constructor(config: AxelarRecoveryAPIConfig) {
@@ -16,7 +16,7 @@ export class AxelarDepositRecoveryAPI extends AxelarRecoveryApi {
   }
 
   public async confirmDeposit(params: ConfirmDepositRequest) {
-    await isValidChainIdentifier(params.from, this.environment);
+    await throwIfInvalidChainId(params.from, this.environment);
 
     const chain: ChainInfo = (
       await loadChains({

--- a/src/libs/TransactionRecoveryApi/AxelarGMPRecoveryAPI.ts
+++ b/src/libs/TransactionRecoveryApi/AxelarGMPRecoveryAPI.ts
@@ -212,6 +212,9 @@ export class AxelarGMPRecoveryAPI extends AxelarRecoveryApi {
     gasTokenSymbol: GasToken | string,
     options: QueryGasFeeOptions
   ): Promise<string> {
+    await isValidChainIdentifier(sourceChain, this.environment);
+    await isValidChainIdentifier(destinationChain, this.environment);
+
     const provider = options.provider || getDefaultProvider(sourceChain, this.environment);
     const receipt = await provider.getTransactionReceipt(txHash);
     const paidGasFee = getGasAmountFromTxReceipt(receipt) || "0";
@@ -454,9 +457,6 @@ export class AxelarGMPRecoveryAPI extends AxelarRecoveryApi {
     paidGasFee: string,
     options: QueryGasFeeOptions
   ) {
-    await isValidChainIdentifier(sourceChain, this.environment);
-    await isValidChainIdentifier(destinationChain, this.environment);
-
     const totalGasFee = await this.axelarQueryApi.estimateGasFee(
       sourceChain,
       destinationChain,

--- a/src/libs/TransactionRecoveryApi/AxelarGMPRecoveryAPI.ts
+++ b/src/libs/TransactionRecoveryApi/AxelarGMPRecoveryAPI.ts
@@ -48,7 +48,7 @@ import {
   UnsupportedGasTokenError,
 } from "./constants/error";
 import { callExecute, CALL_EXECUTE_ERROR } from "./helpers";
-import { asyncRetry, sleep, isValidChainIdentifier } from "../../utils";
+import { asyncRetry, sleep, throwIfInvalidChainId } from "../../utils";
 import { BatchedCommandsResponse } from "@axelar-network/axelarjs-types/axelar/evm/v1beta1/query";
 import s3 from "./constants/s3";
 import { Interface } from "ethers/lib/utils";
@@ -186,8 +186,8 @@ export class AxelarGMPRecoveryAPI extends AxelarRecoveryApi {
     gasTokenSymbol: GasToken | string,
     options: QueryGasFeeOptions
   ): Promise<string> {
-    await isValidChainIdentifier(sourceChain, this.environment);
-    await isValidChainIdentifier(destinationChain, this.environment);
+    await throwIfInvalidChainId(sourceChain, this.environment);
+    await throwIfInvalidChainId(destinationChain, this.environment);
     await this.axelarQueryApi.throwIfInactiveChain(sourceChain);
     await this.axelarQueryApi.throwIfInactiveChain(destinationChain);
 
@@ -214,8 +214,8 @@ export class AxelarGMPRecoveryAPI extends AxelarRecoveryApi {
     gasTokenSymbol: GasToken | string,
     options: QueryGasFeeOptions
   ): Promise<string> {
-    await isValidChainIdentifier(sourceChain, this.environment);
-    await isValidChainIdentifier(destinationChain, this.environment);
+    await throwIfInvalidChainId(sourceChain, this.environment);
+    await throwIfInvalidChainId(destinationChain, this.environment);
     await this.axelarQueryApi.throwIfInactiveChain(sourceChain);
     await this.axelarQueryApi.throwIfInactiveChain(destinationChain);
 

--- a/src/libs/TransactionRecoveryApi/AxelarGMPRecoveryAPI.ts
+++ b/src/libs/TransactionRecoveryApi/AxelarGMPRecoveryAPI.ts
@@ -188,8 +188,6 @@ export class AxelarGMPRecoveryAPI extends AxelarRecoveryApi {
   ): Promise<string> {
     await throwIfInvalidChainId(sourceChain, this.environment);
     await throwIfInvalidChainId(destinationChain, this.environment);
-    await this.axelarQueryApi.throwIfInactiveChain(sourceChain);
-    await this.axelarQueryApi.throwIfInactiveChain(destinationChain);
 
     const provider = options.provider || getDefaultProvider(sourceChain, this.environment);
     const receipt = await provider.getTransactionReceipt(txHash);
@@ -216,8 +214,6 @@ export class AxelarGMPRecoveryAPI extends AxelarRecoveryApi {
   ): Promise<string> {
     await throwIfInvalidChainId(sourceChain, this.environment);
     await throwIfInvalidChainId(destinationChain, this.environment);
-    await this.axelarQueryApi.throwIfInactiveChain(sourceChain);
-    await this.axelarQueryApi.throwIfInactiveChain(destinationChain);
 
     const provider = options.provider || getDefaultProvider(sourceChain, this.environment);
     const receipt = await provider.getTransactionReceipt(txHash);

--- a/src/libs/TransactionRecoveryApi/AxelarGMPRecoveryAPI.ts
+++ b/src/libs/TransactionRecoveryApi/AxelarGMPRecoveryAPI.ts
@@ -188,6 +188,8 @@ export class AxelarGMPRecoveryAPI extends AxelarRecoveryApi {
   ): Promise<string> {
     await isValidChainIdentifier(sourceChain, this.environment);
     await isValidChainIdentifier(destinationChain, this.environment);
+    await this.axelarQueryApi.throwIfInactiveChain(sourceChain);
+    await this.axelarQueryApi.throwIfInactiveChain(destinationChain);
 
     const provider = options.provider || getDefaultProvider(sourceChain, this.environment);
     const receipt = await provider.getTransactionReceipt(txHash);
@@ -214,6 +216,8 @@ export class AxelarGMPRecoveryAPI extends AxelarRecoveryApi {
   ): Promise<string> {
     await isValidChainIdentifier(sourceChain, this.environment);
     await isValidChainIdentifier(destinationChain, this.environment);
+    await this.axelarQueryApi.throwIfInactiveChain(sourceChain);
+    await this.axelarQueryApi.throwIfInactiveChain(destinationChain);
 
     const provider = options.provider || getDefaultProvider(sourceChain, this.environment);
     const receipt = await provider.getTransactionReceipt(txHash);

--- a/src/libs/TransactionRecoveryApi/AxelarRecoveryApi.ts
+++ b/src/libs/TransactionRecoveryApi/AxelarRecoveryApi.ts
@@ -8,7 +8,7 @@ import EVMClient from "./client/EVMClient";
 import { TransactionRequest } from "@ethersproject/providers";
 import rpcInfo from "./constants/chain";
 import { BigNumber } from "ethers";
-import { isValidChainIdentifier } from "../../utils";
+import { throwIfInvalidChainId } from "../../utils";
 
 export enum GMPStatus {
   SRC_GATEWAY_CALLED = "source_gateway_called",
@@ -246,19 +246,19 @@ export class AxelarRecoveryApi {
   public async queryBatchedCommands(chainId: string, batchCommandId = "") {
     if (!this.axelarQuerySvc)
       this.axelarQuerySvc = await AxelarQueryClient.initOrGetAxelarQueryClient(this.config);
-    await isValidChainIdentifier(chainId, this.environment);
+    await throwIfInvalidChainId(chainId, this.environment);
     return this.axelarQuerySvc.evm.BatchedCommands({ chain: chainId, id: batchCommandId });
   }
 
   public async queryGatewayAddress({ chain }: { chain: string }) {
     if (!this.axelarQuerySvc)
       this.axelarQuerySvc = await AxelarQueryClient.initOrGetAxelarQueryClient(this.config);
-    await isValidChainIdentifier(chain, this.environment);
+    await throwIfInvalidChainId(chain, this.environment);
     return this.axelarQuerySvc.evm.GatewayAddress({ chain });
   }
 
   public async getSignedTxAndBroadcast(chain: string, data: string) {
-    await isValidChainIdentifier(chain, this.environment);
+    await throwIfInvalidChainId(chain, this.environment);
     const gatewayInfo = await this.queryGatewayAddress({ chain });
     const evmClient = new EVMClient({
       rpcUrl: rpcInfo[this.environment].rpcMap[chain],
@@ -276,7 +276,7 @@ export class AxelarRecoveryApi {
   }
 
   public async sendApproveTx(chain: string, data: string, evmWalletDetails: EvmWalletDetails) {
-    await isValidChainIdentifier(chain, this.environment);
+    await throwIfInvalidChainId(chain, this.environment);
     const gatewayInfo = await this.queryGatewayAddress({ chain });
     const evmClient = new EVMClient({
       rpcUrl: rpcInfo[this.environment].rpcMap[chain],
@@ -297,7 +297,7 @@ export class AxelarRecoveryApi {
     data: string,
     evmWalletDetails = { useWindowEthereum: true }
   ) {
-    await isValidChainIdentifier(chain, this.environment);
+    await throwIfInvalidChainId(chain, this.environment);
     const gatewayInfo = await this.queryGatewayAddress({ chain });
     const evmClient = new EVMClient({
       rpcUrl: rpcInfo[this.environment].rpcMap[chain],

--- a/src/libs/test/AxelarAssetTransfer.spec.ts
+++ b/src/libs/test/AxelarAssetTransfer.spec.ts
@@ -3,6 +3,7 @@ import { CHAINS, CLIENT_API_GET_OTC, CLIENT_API_POST_TRANSFER_ASSET } from "../.
 import { AxelarAssetTransfer } from "../AxelarAssetTransfer";
 import { Environment, EvmChain } from "../types";
 import {
+  activeChainsStub,
   apiErrorStub,
   depositAddressPayloadStub,
   ethAddressStub,
@@ -21,6 +22,7 @@ describe("AxelarAssetTransfer", () => {
     jest
       .spyOn(AxelarAssetTransfer.prototype as any, "getSocketService")
       .mockReturnValueOnce(socket);
+
     jest.clearAllMocks();
   });
 
@@ -31,6 +33,7 @@ describe("AxelarAssetTransfer", () => {
       bridge = new AxelarAssetTransfer({
         environment: Environment.TESTNET,
       });
+      jest.spyOn(bridge.axelarQueryApi, "getActiveChains").mockResolvedValue(activeChainsStub());
     });
 
     describe("AxelarAssetTransfer", () => {
@@ -67,6 +70,7 @@ describe("AxelarAssetTransfer", () => {
       bridge = new AxelarAssetTransfer({
         environment: Environment.TESTNET,
       });
+      jest.spyOn(bridge.axelarQueryApi, "getActiveChains").mockResolvedValue(activeChainsStub());
     });
 
     describe("on error", () => {
@@ -108,6 +112,9 @@ describe("AxelarAssetTransfer", () => {
 
         beforeEach(async () => {
           jest.spyOn(bridge.api, "get").mockResolvedValue(otcStub());
+          jest
+            .spyOn(bridge.axelarQueryApi, "getActiveChains")
+            .mockResolvedValue(activeChainsStub());
           otc = await bridge.getOneTimeCode(ethAddressStub(), uuidStub());
         });
 
@@ -136,6 +143,7 @@ describe("AxelarAssetTransfer", () => {
       bridge = new AxelarAssetTransfer({
         environment: Environment.TESTNET,
       });
+      jest.spyOn(bridge.axelarQueryApi, "getActiveChains").mockResolvedValue(activeChainsStub());
     });
 
     describe("on error", () => {
@@ -231,6 +239,7 @@ describe("AxelarAssetTransfer", () => {
       bridge = new AxelarAssetTransfer({
         environment: Environment.TESTNET,
       });
+      jest.spyOn(bridge.axelarQueryApi, "getActiveChains").mockResolvedValue(activeChainsStub());
     });
 
     describe("on error", () => {
@@ -328,6 +337,7 @@ describe("AxelarAssetTransfer", () => {
         jest.spyOn(bridge, "getOneTimeCode").mockResolvedValue(otcStub());
         jest.spyOn(bridge, "getInitRoomId").mockResolvedValue(roomIdStub().roomId);
         jest.spyOn(bridge, "getLinkEvent").mockResolvedValue(linkEventStub().newRoomId);
+        jest.spyOn(bridge.axelarQueryApi, "getActiveChains").mockResolvedValue(activeChainsStub());
         response = await bridge.getDepositAddress(fromChain, toChain, depositAddress, asset);
         responseWithObjectParams = await bridge.getDepositAddress({
           fromChain,
@@ -359,6 +369,7 @@ describe("AxelarAssetTransfer", () => {
         jest
           .spyOn(bridge, "getDepositServiceContractAddress")
           .mockResolvedValue("0xc1DCb196BA862B337Aa23eDA1Cb9503C0801b955");
+        jest.spyOn(bridge.axelarQueryApi, "getActiveChains").mockResolvedValue(activeChainsStub());
       });
       it("should be able to generate a deposit address offline", async () => {
         await expect(
@@ -382,6 +393,7 @@ describe("AxelarAssetTransfer", () => {
         jest
           .spyOn(bridge, "getDepositServiceContractAddress")
           .mockResolvedValue("0xc1DCb196BA862B337Aa23eDA1Cb9503C0801b955");
+        jest.spyOn(bridge.axelarQueryApi, "getActiveChains").mockResolvedValue(activeChainsStub());
       });
       it("should be able to generate a deposit address offline", () => {
         const depositAddress = bridge.validateOfflineDepositAddress(
@@ -418,6 +430,7 @@ describe("AxelarAssetTransfer", () => {
           .spyOn(bridge, "getDepositServiceContractAddress")
           .mockResolvedValue("0xc1DCb196BA862B337Aa23eDA1Cb9503C0801b955");
         jest.spyOn(bridge, "getERC20Denom").mockResolvedValue("wavax-wei");
+        jest.spyOn(bridge.axelarQueryApi, "getActiveChains").mockResolvedValue(activeChainsStub());
       });
       it("should be able to retrieve the deposit address from microservices for erc20 unwrap", async () => {
         await expect(
@@ -456,6 +469,7 @@ describe("AxelarAssetTransfer", () => {
         jest
           .spyOn(bridge, "getDepositAddressForNativeUnwrap")
           .mockResolvedValue("0xc1DCb196BA862B337Aa23eDA1Cb9503C0801b955");
+        jest.spyOn(bridge.axelarQueryApi, "getActiveChains").mockResolvedValue(activeChainsStub());
       });
       it("should call getDepositAddressForNativeWrap and not getDepositAddressForNativeUnwrap", async () => {
         await expect(

--- a/src/libs/test/AxelarQueryAPI.spec.ts
+++ b/src/libs/test/AxelarQueryAPI.spec.ts
@@ -6,6 +6,7 @@ import { ethers } from "ethers";
 import { CHAINS } from "../../chains";
 import { AxelarQueryAPI } from "../AxelarQueryAPI";
 import { Environment, EvmChain, GasToken } from "../types";
+import { activeChainsStub } from "./stubs";
 
 describe("AxelarQueryAPI", () => {
   const api = new AxelarQueryAPI({ environment: Environment.TESTNET });
@@ -93,6 +94,7 @@ describe("AxelarQueryAPI", () => {
 
   describe("getNativeGasBaseFee", () => {
     test("It should return base fee for a certain source chain / destination chain combination", async () => {
+      jest.spyOn(api, "getActiveChains").mockResolvedValueOnce(activeChainsStub());
       const gasResult = await api.getNativeGasBaseFee(
         CHAINS.TESTNET.AVALANCHE as EvmChain,
         CHAINS.TESTNET.ETHEREUM as EvmChain
@@ -138,6 +140,20 @@ describe("AxelarQueryAPI", () => {
     test("It should get a list of active chains", async () => {
       const activeChains = await api.getActiveChains();
       expect(activeChains.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe("throwIfInactiveChain", () => {
+    test("It should throw if the chain does not get included in a active-chains list", async () => {
+      jest.spyOn(api, "getActiveChains").mockResolvedValue(["avalanche", "polygon"]);
+      await expect(api.throwIfInactiveChain("ethereum")).rejects.toThrowError(
+        "Chain ethereum is not active"
+      );
+    });
+
+    test("It should throw if the chain does not get included in a active-chains list", async () => {
+      jest.spyOn(api, "getActiveChains").mockResolvedValue(["avalanche", "polygon"]);
+      await expect(api.throwIfInactiveChain("avalanche")).resolves.toBeUndefined();
     });
   });
 });

--- a/src/libs/test/AxelarQueryAPI.spec.ts
+++ b/src/libs/test/AxelarQueryAPI.spec.ts
@@ -133,4 +133,11 @@ describe("AxelarQueryAPI", () => {
       });
     });
   });
+
+  describe("getActiveChains", () => {
+    test("It should get a list of active chains", async () => {
+      const activeChains = await api.getActiveChains();
+      expect(activeChains.length).toBeGreaterThan(0);
+    });
+  });
 });

--- a/src/libs/test/TransactionRecoveryAPI/AxelarGMPRecoveryAPI.spec.ts
+++ b/src/libs/test/TransactionRecoveryAPI/AxelarGMPRecoveryAPI.spec.ts
@@ -31,6 +31,7 @@ import { AXELAR_GATEWAY } from "../../AxelarGateway";
 import { GMPStatus } from "../../TransactionRecoveryApi/AxelarRecoveryApi";
 import * as ContractCallHelper from "../../TransactionRecoveryApi/helpers/contractCallHelper";
 import {
+  activeChainsStub,
   axelarTxResponseStub,
   batchedCommandResponseStub,
   contractReceiptStub,
@@ -292,6 +293,8 @@ describe("AxelarDepositRecoveryAPI", () => {
         .connect(userWallet)
         .approve(contract.address, ethers.constants.MaxUint256)
         .then((tx: ContractTransaction) => tx.wait(1));
+
+      jest.spyOn(api.axelarQueryApi, "getActiveChains").mockResolvedValue(activeChainsStub());
     });
 
     test("it should return 'gas required' - 'gas paid' given 'gas required' > 'gas paid'", async () => {
@@ -316,6 +319,7 @@ describe("AxelarDepositRecoveryAPI", () => {
       jest
         .spyOn(api.axelarQueryApi, "estimateGasFee")
         .mockResolvedValueOnce(gasRequired.toString());
+      jest.spyOn(api.axelarQueryApi, "getActiveChains").mockResolvedValueOnce(activeChainsStub());
 
       // Calculate how many gas we need to add more.
       const wantedGasFee = await api.calculateNativeGasFee(
@@ -382,6 +386,8 @@ describe("AxelarDepositRecoveryAPI", () => {
       jest
         .spyOn(api, "getGasReceiverContractAddress")
         .mockResolvedValue(gasReceiverContract.address);
+
+      jest.spyOn(api.axelarQueryApi, "getActiveChains").mockResolvedValue(activeChainsStub());
     });
 
     beforeAll(async () => {
@@ -688,6 +694,7 @@ describe("AxelarDepositRecoveryAPI", () => {
       jest
         .spyOn(api, "getGasReceiverContractAddress")
         .mockResolvedValueOnce(gasReceiverContract.address);
+      jest.spyOn(api.axelarQueryApi, "getActiveChains").mockResolvedValue(activeChainsStub());
     });
 
     beforeAll(async () => {

--- a/src/libs/test/stubs/index.ts
+++ b/src/libs/test/stubs/index.ts
@@ -32,7 +32,7 @@ export const activeChainsStub = () => [
   "regen",
   "secret",
   "stargaze",
-  "terra-2",
+  "terra-3",
   "umee",
 ];
 

--- a/src/libs/test/stubs/index.ts
+++ b/src/libs/test/stubs/index.ts
@@ -7,6 +7,35 @@ export const ethAddressStub = () => "0xF16DfB26e1FEc993E085092563ECFAEaDa7eD7fD"
 
 export const terraAddressStub = () => "terra1qem4njhac8azalrav7shvp06myhqldpmkk3p0t";
 
+export const activeChainsStub = () => [
+  "agoric",
+  "assetmantle",
+  "aurora",
+  "avalanche",
+  "axelarnet",
+  "binance",
+  "comdex",
+  "cosmoshub",
+  "crescent",
+  "e-money",
+  "ethereum",
+  "evmos",
+  "fantom",
+  "fetch",
+  "injective",
+  "juno",
+  "ki",
+  "kujira",
+  "moonbeam",
+  "osmosis",
+  "polygon",
+  "regen",
+  "secret",
+  "stargaze",
+  "terra-2",
+  "umee",
+];
+
 export const otcStub = () => ({
   otc: "hr64_XnjNE",
   validationMsg:

--- a/src/libs/types/index.ts
+++ b/src/libs/types/index.ts
@@ -60,7 +60,7 @@ export interface TxOption {
 }
 
 export type AxelarAssetTransferConfig = {
-  environment: "mainnet" | "testnet" | "devnet";
+  environment: Environment;
   auth?: "local" | "metamask";
   overwriteResourceUrl?: string;
 };

--- a/src/utils/validateChain.ts
+++ b/src/utils/validateChain.ts
@@ -33,7 +33,7 @@ function findSimilarInArray(array: Array<string>, wordsToFind: string) {
   return bestMatch;
 }
 
-export async function isValidChainIdentifier(chain: string, environment: Environment) {
+export async function throwIfInvalidChainId(chain: string, environment: Environment) {
   const [chainValid] = await Promise.all([validateChainIdentifier(chain, environment)]);
   if (!chainValid.foundChain)
     throw new Error(`Invalid chain identifier for ${chain}. Did you mean ${chainValid.bestMatch}?`);


### PR DESCRIPTION
# Description

Closes #163 

Adds the following public functions:
- `getActiveChains(): Promise<string[]>` returns a list of active chains
- `isChainActive(chainId: string)`: Check if a chain is active.
- `throwIfInactiveChain(chainId: string)`: Throw an error if a chain is inactive. (for internal use purposes)

The `throwIfInactiveChain` check is added to the very beginning of the following apis:
### AxelarAssetTransfer
- getDepositAddressForNativeWrap
- getDepositAddressForNativeUnwrap
- getDepositAddressFromRemote
- validateOfflineDepositAddress
- getInitRoomId

### AxelarQueryAPI
- getNativeGasBaseFee
- estimateGasFee

### AxelarGMPRecoveryAPI
- calculateNativeGasFee
- calculateGasFee

# Refactoring
- Change the function name from `isValidChainIdentifier` to `throwIfInvalidChainId`