### PR TITLE
Change the default refund address

### DIFF
--- a/src/libs/AxelarAssetTransfer.ts
+++ b/src/libs/AxelarAssetTransfer.ts
@@ -214,7 +214,7 @@ export class AxelarAssetTransfer {
           ]);
 
     const address = getCreate2Address(
-      await this.axelarQueryApi.getContractAddressFromConfig(fromChain, "gas_service"),
+      await this.axelarQueryApi.getContractAddressFromConfig(fromChain, "deposit_service"),
       hexSalt,
       keccak256(
         solidityPack(

--- a/src/libs/AxelarQueryAPI.ts
+++ b/src/libs/AxelarQueryAPI.ts
@@ -240,6 +240,9 @@ export class AxelarQueryAPI {
   }
 
   public async getGasReceiverContractAddress(chainId: string): Promise<string> {
+    await throwIfInvalidChainIds([chainId], this.environment);
+    await this.throwIfInactiveChains([chainId]);
+
     const chains = await loadChains({ environment: this.environment });
     const selectedChain = chains.find((chain) => chain.id === chainId);
     if (!selectedChain) throw `getGasReceiverContractAddress() ${chainId} not found`;
@@ -247,7 +250,7 @@ export class AxelarQueryAPI {
     return await fetch(s3[this.environment])
       .then((res) => res.json())
       .then((body) => body.assets.network[chainName.toLowerCase()]?.gas_service)
-      .catch(() => "");
+      .catch(() => undefined);
   }
 
   /**

--- a/src/libs/AxelarQueryAPI.ts
+++ b/src/libs/AxelarQueryAPI.ts
@@ -239,17 +239,14 @@ export class AxelarQueryAPI {
     return result;
   }
 
-  public async getGasReceiverContractAddress(chainId: string): Promise<string> {
-    await throwIfInvalidChainIds([chainId], this.environment);
-    await this.throwIfInactiveChains([chainId]);
-
+  public async getContractAddressFromConfig(chainId: string, contractKey: string): Promise<string> {
     const chains = await loadChains({ environment: this.environment });
     const selectedChain = chains.find((chain) => chain.id === chainId);
     if (!selectedChain) throw `getGasReceiverContractAddress() ${chainId} not found`;
     const { chainName } = selectedChain;
     return await fetch(s3[this.environment])
       .then((res) => res.json())
-      .then((body) => body.assets.network[chainName.toLowerCase()]?.gas_service)
+      .then((body) => body.assets.network[chainName.toLowerCase()][contractKey])
       .catch(() => undefined);
   }
 

--- a/src/libs/AxelarQueryAPI.ts
+++ b/src/libs/AxelarQueryAPI.ts
@@ -6,6 +6,7 @@ import { RestService } from "../services";
 import { AxelarQueryAPIConfig, BaseFeeResponse, Environment, EvmChain, GasToken } from "./types";
 import { DEFAULT_ESTIMATED_GAS } from "./TransactionRecoveryApi/constants/contract";
 import { AxelarQueryClient, AxelarQueryClientType } from "./AxelarQueryClient";
+import fetch from "cross-fetch";
 import {
   ChainStatus,
   FeeInfoResponse,
@@ -224,7 +225,7 @@ export class AxelarQueryAPI {
    * Get the asset config for an asset on a given chain given its denom
    * @param denom
    * @param chainName
-   * @returns
+   * @returns asset config
    */
   public async getAssetConfigFromDenom(denom: string, chainName: string) {
     if (!this.allAssets) await this._initializeAssets();
@@ -239,10 +240,17 @@ export class AxelarQueryAPI {
     return result;
   }
 
+  /**
+   * Get the contract address from the chainId and the contractKey
+   * @param chainId - the chainId of the chain
+   * @param contractKey - the key of the contract in the config file.
+   * A valid contractKey can be found here https://github.com/axelarnetwork/chains/blob/790f08350e792e27412ded6721c13ce78267fd72/testnet-config.json#L1951-L1954 e.g. ("gas_service", "deposit_service", "default_refund_collector")
+   * @returns the contract address
+   */
   public async getContractAddressFromConfig(chainId: string, contractKey: string): Promise<string> {
     const chains = await loadChains({ environment: this.environment });
     const selectedChain = chains.find((chain) => chain.id === chainId);
-    if (!selectedChain) throw `getGasReceiverContractAddress() ${chainId} not found`;
+    if (!selectedChain) throw `getContractAddressFromConfig() ${chainId} not found`;
     const { chainName } = selectedChain;
     return await fetch(s3[this.environment])
       .then((res) => res.json())

--- a/src/libs/TransactionRecoveryApi/AxelarGMPRecoveryAPI.ts
+++ b/src/libs/TransactionRecoveryApi/AxelarGMPRecoveryAPI.ts
@@ -234,7 +234,10 @@ export class AxelarGMPRecoveryAPI extends AxelarRecoveryApi {
     const evmWalletDetails = options?.evmWalletDetails || { useWindowEthereum: true };
     const signer = this.getSigner(chain, evmWalletDetails);
     const signerAddress = await signer.getAddress();
-    const gasReceiverAddress = await this.axelarQueryApi.getGasReceiverContractAddress(chain);
+    const gasReceiverAddress = await this.axelarQueryApi.getContractAddressFromConfig(
+      chain,
+      "gas_service"
+    );
     const nativeGasTokenSymbol = NATIVE_GAS_TOKEN_SYMBOL[chain];
     const receipt = await signer.provider.getTransactionReceipt(txHash);
 
@@ -307,7 +310,10 @@ export class AxelarGMPRecoveryAPI extends AxelarRecoveryApi {
     const evmWalletDetails = options?.evmWalletDetails || { useWindowEthereum: true };
     const signer = this.getSigner(chain, evmWalletDetails);
     const signerAddress = await signer.getAddress();
-    const gasReceiverAddress = await this.axelarQueryApi.getGasReceiverContractAddress(chain);
+    const gasReceiverAddress = await this.axelarQueryApi.getContractAddressFromConfig(
+      chain,
+      "gas_service"
+    );
     const gasTokenContract = new ethers.Contract(gasTokenAddress, Erc20, signer.provider);
     const gasTokenSymbol = await gasTokenContract.symbol().catch(() => undefined);
 

--- a/src/libs/TransactionRecoveryApi/AxelarGMPRecoveryAPI.ts
+++ b/src/libs/TransactionRecoveryApi/AxelarGMPRecoveryAPI.ts
@@ -50,9 +50,7 @@ import {
 import { callExecute, CALL_EXECUTE_ERROR } from "./helpers";
 import { asyncRetry, sleep, throwIfInvalidChainIds } from "../../utils";
 import { BatchedCommandsResponse } from "@axelar-network/axelarjs-types/axelar/evm/v1beta1/query";
-import s3 from "./constants/s3";
 import { Interface } from "ethers/lib/utils";
-import { loadChains } from "../../chains";
 
 export class AxelarGMPRecoveryAPI extends AxelarRecoveryApi {
   axelarQueryApi: AxelarQueryAPI;
@@ -236,7 +234,7 @@ export class AxelarGMPRecoveryAPI extends AxelarRecoveryApi {
     const evmWalletDetails = options?.evmWalletDetails || { useWindowEthereum: true };
     const signer = this.getSigner(chain, evmWalletDetails);
     const signerAddress = await signer.getAddress();
-    const gasReceiverAddress = await this.getGasReceiverContractAddress(chain);
+    const gasReceiverAddress = await this.axelarQueryApi.getGasReceiverContractAddress(chain);
     const nativeGasTokenSymbol = NATIVE_GAS_TOKEN_SYMBOL[chain];
     const receipt = await signer.provider.getTransactionReceipt(txHash);
 
@@ -309,7 +307,7 @@ export class AxelarGMPRecoveryAPI extends AxelarRecoveryApi {
     const evmWalletDetails = options?.evmWalletDetails || { useWindowEthereum: true };
     const signer = this.getSigner(chain, evmWalletDetails);
     const signerAddress = await signer.getAddress();
-    const gasReceiverAddress = await this.getGasReceiverContractAddress(chain);
+    const gasReceiverAddress = await this.axelarQueryApi.getGasReceiverContractAddress(chain);
     const gasTokenContract = new ethers.Contract(gasTokenAddress, Erc20, signer.provider);
     const gasTokenSymbol = await gasTokenContract.symbol().catch(() => undefined);
 
@@ -478,16 +476,5 @@ export class AxelarGMPRecoveryAPI extends AxelarRecoveryApi {
     };
     const evmClient = new EVMClient(evmClientConfig);
     return evmClient.getSigner();
-  }
-
-  public async getGasReceiverContractAddress(chainId: string): Promise<string> {
-    const chains = await loadChains({ environment: this.environment });
-    const selectedChain = chains.find((chain) => chain.id === chainId);
-    if (!selectedChain) throw `getGasReceiverContractAddress() ${chainId} not found`;
-    const { chainName } = selectedChain;
-    return await fetch(s3[this.environment])
-      .then((res) => res.json())
-      .then((body) => body.assets.network[chainName.toLowerCase()]?.gas_service)
-      .catch(() => "");
   }
 }

--- a/src/libs/test/AxelarAssetTransfer.spec.ts
+++ b/src/libs/test/AxelarAssetTransfer.spec.ts
@@ -367,7 +367,7 @@ describe("AxelarAssetTransfer", () => {
       beforeEach(async () => {
         jest.clearAllMocks();
         jest
-          .spyOn(bridge, "getDepositServiceContractAddress")
+          .spyOn(bridge.axelarQueryApi, "getContractAddressFromConfig")
           .mockResolvedValue("0xc1DCb196BA862B337Aa23eDA1Cb9503C0801b955");
         jest.spyOn(bridge.axelarQueryApi, "getActiveChains").mockResolvedValue(activeChainsStub());
       });
@@ -391,7 +391,7 @@ describe("AxelarAssetTransfer", () => {
         jest.clearAllMocks();
         jest.spyOn(bridge, "getDepositAddressFromRemote").mockResolvedValue({ address });
         jest
-          .spyOn(bridge, "getDepositServiceContractAddress")
+          .spyOn(bridge.axelarQueryApi, "getContractAddressFromConfig")
           .mockResolvedValue("0xc1DCb196BA862B337Aa23eDA1Cb9503C0801b955");
         jest.spyOn(bridge.axelarQueryApi, "getActiveChains").mockResolvedValue(activeChainsStub());
       });
@@ -427,7 +427,7 @@ describe("AxelarAssetTransfer", () => {
           .mockResolvedValue({ address: unwrapAddress });
         jest.spyOn(bridge, "getDepositAddress").mockResolvedValue(unwrapAddress);
         jest
-          .spyOn(bridge, "getDepositServiceContractAddress")
+          .spyOn(bridge.axelarQueryApi, "getContractAddressFromConfig")
           .mockResolvedValue("0xc1DCb196BA862B337Aa23eDA1Cb9503C0801b955");
         jest.spyOn(bridge, "getERC20Denom").mockResolvedValue("wavax-wei");
         jest.spyOn(bridge.axelarQueryApi, "getActiveChains").mockResolvedValue(activeChainsStub());

--- a/src/libs/test/AxelarQueryAPI.spec.ts
+++ b/src/libs/test/AxelarQueryAPI.spec.ts
@@ -177,7 +177,7 @@ describe("AxelarQueryAPI", () => {
     });
 
     test("it should retrieve the gas receiver address remotely", async () => {
-      await api.getGasReceiverContractAddress(EvmChain.MOONBEAM).then((res) => {
+      await api.getContractAddressFromConfig(EvmChain.MOONBEAM, "gas_service").then((res) => {
         expect(res).toBeDefined();
       });
     });

--- a/src/libs/test/AxelarQueryAPI.spec.ts
+++ b/src/libs/test/AxelarQueryAPI.spec.ts
@@ -168,4 +168,18 @@ describe("AxelarQueryAPI", () => {
       await expect(api.throwIfInactiveChains(["avalanche"])).resolves.toBeUndefined();
     });
   });
+
+  describe("getGasReceiverContractAddress", () => {
+    let api: AxelarQueryAPI;
+
+    beforeEach(async () => {
+      api = new AxelarQueryAPI({ environment: Environment.TESTNET });
+    });
+
+    test("it should retrieve the gas receiver address remotely", async () => {
+      await api.getGasReceiverContractAddress(EvmChain.MOONBEAM).then((res) => {
+        expect(res).toBeDefined();
+      });
+    });
+  });
 });

--- a/src/libs/test/AxelarQueryAPI.spec.ts
+++ b/src/libs/test/AxelarQueryAPI.spec.ts
@@ -169,7 +169,7 @@ describe("AxelarQueryAPI", () => {
     });
   });
 
-  describe("getGasReceiverContractAddress", () => {
+  describe("getContractAddressFromConfig", () => {
     let api: AxelarQueryAPI;
 
     beforeEach(async () => {

--- a/src/libs/test/TransactionRecoveryAPI/AxelarGMPRecoveryAPI.spec.ts
+++ b/src/libs/test/TransactionRecoveryAPI/AxelarGMPRecoveryAPI.spec.ts
@@ -384,7 +384,7 @@ describe("AxelarDepositRecoveryAPI", () => {
       api = new AxelarGMPRecoveryAPI({ environment: Environment.TESTNET });
       jest.clearAllMocks();
       jest
-        .spyOn(api.axelarQueryApi, "getGasReceiverContractAddress")
+        .spyOn(api.axelarQueryApi, "getContractAddressFromConfig")
         .mockResolvedValue(gasReceiverContract.address);
 
       jest.spyOn(api.axelarQueryApi, "getActiveChains").mockResolvedValue(activeChainsStub());
@@ -692,7 +692,7 @@ describe("AxelarDepositRecoveryAPI", () => {
       jest.clearAllMocks();
       api = new AxelarGMPRecoveryAPI({ environment: Environment.TESTNET });
       jest
-        .spyOn(api.axelarQueryApi, "getGasReceiverContractAddress")
+        .spyOn(api.axelarQueryApi, "getContractAddressFromConfig")
         .mockResolvedValueOnce(gasReceiverContract.address);
       jest.spyOn(api.axelarQueryApi, "getActiveChains").mockResolvedValue(activeChainsStub());
     });

--- a/src/libs/test/TransactionRecoveryAPI/AxelarGMPRecoveryAPI.spec.ts
+++ b/src/libs/test/TransactionRecoveryAPI/AxelarGMPRecoveryAPI.spec.ts
@@ -384,7 +384,7 @@ describe("AxelarDepositRecoveryAPI", () => {
       api = new AxelarGMPRecoveryAPI({ environment: Environment.TESTNET });
       jest.clearAllMocks();
       jest
-        .spyOn(api, "getGasReceiverContractAddress")
+        .spyOn(api.axelarQueryApi, "getGasReceiverContractAddress")
         .mockResolvedValue(gasReceiverContract.address);
 
       jest.spyOn(api.axelarQueryApi, "getActiveChains").mockResolvedValue(activeChainsStub());
@@ -692,7 +692,7 @@ describe("AxelarDepositRecoveryAPI", () => {
       jest.clearAllMocks();
       api = new AxelarGMPRecoveryAPI({ environment: Environment.TESTNET });
       jest
-        .spyOn(api, "getGasReceiverContractAddress")
+        .spyOn(api.axelarQueryApi, "getGasReceiverContractAddress")
         .mockResolvedValueOnce(gasReceiverContract.address);
       jest.spyOn(api.axelarQueryApi, "getActiveChains").mockResolvedValue(activeChainsStub());
     });
@@ -1203,19 +1203,6 @@ describe("AxelarDepositRecoveryAPI", () => {
       });
 
       expect(mockGMPApi).toHaveBeenCalledTimes(1);
-    });
-  });
-  describe("getGasReceiverContractAddress", () => {
-    let api: AxelarGMPRecoveryAPI;
-
-    beforeEach(async () => {
-      api = new AxelarGMPRecoveryAPI({ environment: Environment.TESTNET });
-    });
-
-    test("it should retrieve the gas receiver address remotely", async () => {
-      await api.getGasReceiverContractAddress(EvmChain.MOONBEAM).then((res) => {
-        expect(res).toBeDefined();
-      });
     });
   });
 });


### PR DESCRIPTION
# Description

Closes #216 

- Removed `getGasReceiverContractAddress` and `getDepositServiceContractAddress` functions in `AxelarAssetTransfer` and a duplicated function.
- Added more flexible `getContractAddressFromConfig` function in `AxelarQueryAPI`
- Changed the default `refundAddress` to `default_refund_collector`