### PR TITLE
Add `timeSpent` for `queryTransactionStatus` API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - upgrade axelarjs-types dependency to `v0.27.0`
 - update default axelar rpc & lcd endpoints in testnet/mainnet from quickapi to imperator
 - fix [native gas estimates](https://github.com/axelarnetwork/axelarjs-sdk/pull/193)
+- added `timeSpent` field to the `queryTransactionStatus` API.
+- added more possible values for `GMPStatus` enum.
 
 ## [0.11.7] - 2022-OCTOBER-26
 

--- a/test/e2e/testnet/query-transaction-status.e2e-spec.ts
+++ b/test/e2e/testnet/query-transaction-status.e2e-spec.ts
@@ -1,0 +1,29 @@
+import { AxelarRecoveryApi, Environment } from "../../../src";
+
+describe("Query Transaction Status", () => {
+  jest.setTimeout(20000);
+  let sdk: AxelarRecoveryApi;
+
+  beforeAll(() => {
+    sdk = new AxelarRecoveryApi({
+      environment: Environment.TESTNET,
+    });
+  });
+
+  it("should include timeSpent", async () => {
+    // the sample tx hashes are from the testnet
+    // it contains all finalized statuses to ensure the `timeSpent` is always included.
+    const sampleTxHashes = [
+      "0xd563e708d99da0c7d7cdd613183d6a45f21dd0e1237cd5568551861f3bf3767a", // failed
+      "0x085ad5106880b7a4ecf9ea3ecba3e5637aa6acdeac7158080aa65033aa5731d9", // executed
+    ];
+    const response = await Promise.all(
+      sampleTxHashes.map((hash) => sdk.queryTransactionStatus(hash))
+    );
+    const timeSpents = response.map((result) => result.timeSpent);
+    for (const timeSpent of timeSpents) {
+      expect(timeSpent).toBeDefined();
+      expect(timeSpent?.total).toBeDefined();
+    }
+  });
+});


### PR DESCRIPTION
# Description

This PR adds `timeSpent` into the `queryTransactionStatus` response.

## Note
- `timeSpent` won't always be available. It'll be available at the finalized state e.g. `executed` or `error`
- `timeSpent.total` is not always returned by the `searchGMP` API. So, the SDK calculates it when it doesn't exist, to make sure that it's always presented. (e.g. `0xcbed93b85bac0a04b03722d985197878445492ad29b5deb4472772d706914ca6`)