### PR TITLE
[WIP] Fix incorrect usage of `chainId` and `chainName` as a key

### DIFF
--- a/src/libs/AxelarAssetTransfer.ts
+++ b/src/libs/AxelarAssetTransfer.ts
@@ -402,22 +402,21 @@ export class AxelarAssetTransfer {
 
   async getERC20Denom(chainId: string): Promise<string> {
     const chainList: ChainInfo[] = await loadChains({ environment: this.environment });
-    const chainName = chainList.find(
-      (chainInfo) => chainInfo.id === chainId?.toLowerCase()
-    )?.chainName;
-    if (!chainName) throw new Error(`Chain id ${chainId} does not fit any supported chain`);
+    const _chainId = chainId.toLowerCase();
+    const chain = chainList.find((chainInfo) => chainInfo.id === _chainId);
+    if (!chain) throw new Error(`Chain id ${chainId} does not fit any supported chain`);
 
-    if (!this.evmDenomMap[chainName.toLowerCase()]) {
+    if (!this.evmDenomMap[_chainId]) {
       const staticInfo = await this.getStaticInfo();
-      const denom = staticInfo.chains[chainName.toLowerCase()]?.nativeAsset[0];
+      const denom = staticInfo.chains[_chainId]?.nativeAsset[0];
       if (denom) {
-        this.evmDenomMap[chainName.toLowerCase()] = denom;
+        this.evmDenomMap[_chainId] = denom;
       } else {
         throw new Error(`Asset denom for ${chainId} not found`);
       }
       return denom;
     }
-    return this.evmDenomMap[chainName.toLowerCase()];
+    return this.evmDenomMap[_chainId];
   }
 
   async getStaticInfo(): Promise<Record<string, any>> {

--- a/src/libs/AxelarAssetTransfer.ts
+++ b/src/libs/AxelarAssetTransfer.ts
@@ -402,21 +402,22 @@ export class AxelarAssetTransfer {
 
   async getERC20Denom(chainId: string): Promise<string> {
     const chainList: ChainInfo[] = await loadChains({ environment: this.environment });
-    const _chainId = chainId.toLowerCase();
-    const chain = chainList.find((chainInfo) => chainInfo.id === _chainId);
-    if (!chain) throw new Error(`Chain id ${chainId} does not fit any supported chain`);
+    const chainName = chainList
+      .find((chainInfo) => chainInfo.id === chainId?.toLowerCase())
+      ?.chainName?.toLowerCase();
+    if (!chainName) throw new Error(`Chain id ${chainId} does not fit any supported chain`);
 
-    if (!this.evmDenomMap[_chainId]) {
+    if (!this.evmDenomMap[chainName.toLowerCase()]) {
       const staticInfo = await this.getStaticInfo();
-      const denom = staticInfo.chains[_chainId]?.nativeAsset[0];
+      const denom = staticInfo.chains[chainName]?.nativeAsset[0];
       if (denom) {
-        this.evmDenomMap[_chainId] = denom;
+        this.evmDenomMap[chainName] = denom;
       } else {
         throw new Error(`Asset denom for ${chainId} not found`);
       }
       return denom;
     }
-    return this.evmDenomMap[_chainId];
+    return this.evmDenomMap[chainName];
   }
 
   async getStaticInfo(): Promise<Record<string, any>> {

--- a/src/libs/AxelarQueryAPI.ts
+++ b/src/libs/AxelarQueryAPI.ts
@@ -251,7 +251,6 @@ export class AxelarQueryAPI {
     const chains = await loadChains({ environment: this.environment });
     const selectedChain = chains.find((chain) => chain.id === chainId);
     if (!selectedChain) throw `getContractAddressFromConfig() ${chainId} not found`;
-    const { chainName } = selectedChain;
     return await fetch(s3[this.environment])
       .then((res) => res.json())
       .then((body) => body.assets.network[chainId.toLowerCase()][contractKey])

--- a/src/libs/TransactionRecoveryApi/AxelarRecoveryApi.ts
+++ b/src/libs/TransactionRecoveryApi/AxelarRecoveryApi.ts
@@ -221,8 +221,8 @@ export class AxelarRecoveryApi {
     return chainInfo;
   }
 
-  public async confirmGatewayTx(txHash: string, chainName: string) {
-    const { module, chainIdentifier } = await this.getChainInfo(chainName);
+  public async confirmGatewayTx(txHash: string, chainId: string) {
+    const { module, chainIdentifier } = await this.getChainInfo(chainId);
 
     const txBytes = await this.execRecoveryUrlFetch("/confirm_gateway_tx", {
       txHash,
@@ -233,8 +233,8 @@ export class AxelarRecoveryApi {
     return broadcastCosmosTxBytes(txBytes, this.axelarRpcUrl);
   }
 
-  public async createPendingTransfers(chainName: string) {
-    const { module, chainIdentifier } = await this.getChainInfo(chainName);
+  public async createPendingTransfers(chainId: string) {
+    const { module, chainIdentifier } = await this.getChainInfo(chainId);
 
     const txBytes = await this.execRecoveryUrlFetch("/create_pending_transfers", {
       chain: chainIdentifier[this.environment],
@@ -244,8 +244,8 @@ export class AxelarRecoveryApi {
     return broadcastCosmosTxBytes(txBytes, this.axelarRpcUrl);
   }
 
-  public async executePendingTransfers(chainName: string) {
-    const { module, chainIdentifier } = await this.getChainInfo(chainName);
+  public async executePendingTransfers(chainId: string) {
+    const { module, chainIdentifier } = await this.getChainInfo(chainId);
     const txBytes = await this.execRecoveryUrlFetch("/execute_pending_transfers", {
       chain: chainIdentifier[this.environment],
       module,
@@ -254,8 +254,8 @@ export class AxelarRecoveryApi {
     return broadcastCosmosTxBytes(txBytes, this.axelarRpcUrl);
   }
 
-  public async signCommands(chainName: string) {
-    const { module, chainIdentifier } = await this.getChainInfo(chainName);
+  public async signCommands(chainId: string) {
+    const { module, chainIdentifier } = await this.getChainInfo(chainId);
 
     const txBytes = await this.execRecoveryUrlFetch("/sign_commands", {
       chain: chainIdentifier[this.environment],


### PR DESCRIPTION
# Description

This PR aims to fix all incorrect usages of `chainName` and `chainId`.

Note: I still need to test more because we're using a mix of `chainId` and `chainName` as a key in many config files.
For example,

**In [testnet-config.json](https://github.com/axelarnetwork/chains/blob/main/testnet-config.json) file**:
- we use `ethereum-2` which is **chainId** for network object [here](https://github.com/axelarnetwork/chains/blob/main/testnet-config.json#L1978)
- but we use `ethereum` which is **chainName** for the `asset.chain_aliases` object [here](https://github.com/axelarnetwork/chains/blob/79cafe5df7671eb7e94171e5fca9aa7635ffcafd/testnet-config.json#L1902)