### PR TITLE
feat: adding query for token limit on evm chains

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - fix [native gas estimates](https://github.com/axelarnetwork/axelarjs-sdk/pull/193)
 - added `timeSpent` field to the `queryTransactionStatus` API.
 - added more possible values for `GMPStatus` enum.
+- added `getTransferLimit` query to retrieve the maximum transfer for an asset on a chain
 
 ## [0.11.7] - 2022-OCTOBER-26
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@axelar-network/axelarjs-sdk",
-  "version": "0.12.0-alpha-8",
+  "version": "0.12.0-alpha.10",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@axelar-network/axelarjs-sdk",
-      "version": "0.12.0-alpha-8",
+      "version": "0.12.0-alpha.10",
       "license": "MIT",
       "dependencies": {
         "@axelar-network/axelar-cgp-solidity": "^4.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@axelar-network/axelarjs-sdk",
-  "version": "0.12.0-alpha-8",
+  "version": "0.12.0-alpha.10",
   "description": "The JavaScript SDK for Axelar Network",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",

--- a/src/libs/AxelarQueryAPI.ts
+++ b/src/libs/AxelarQueryAPI.ts
@@ -327,7 +327,7 @@ export class AxelarQueryAPI {
     fromChainId,
     toChainId,
     denom,
-    proportionOfTotalLimitPerTransfer = 1,
+    proportionOfTotalLimitPerTransfer = 0.25,
   }: {
     fromChainId: string;
     toChainId: string;
@@ -343,23 +343,13 @@ export class AxelarQueryAPI {
       denom,
     });
 
-    let fromChainLimit: number, toChainLimit: number;
-
     try {
-      const { limit, outgoing } = fromChainNexusResponse;
-      fromChainLimit = BigNumber.from(limit).sub(BigNumber.from(outgoing)).toNumber();
+      const fromChainLimit = Number(fromChainNexusResponse.limit),
+        toChainLimit = Number(toChainNexusResponse.limit);
+      return Math.min(fromChainLimit, toChainLimit) * proportionOfTotalLimitPerTransfer;
     } catch (e) {
       throw `could not parse response from ${fromChainId} for ${denom}`;
     }
-
-    try {
-      const { limit, incoming } = toChainNexusResponse;
-      toChainLimit = BigNumber.from(limit).sub(BigNumber.from(incoming)).toNumber();
-    } catch (e) {
-      throw `could not parse response from ${toChainId} for ${denom}`;
-    }
-
-    return Math.min(fromChainLimit, toChainLimit) * proportionOfTotalLimitPerTransfer;
   }
 
   async getTransferLimitNexusQuery({

--- a/src/libs/AxelarQueryAPI.ts
+++ b/src/libs/AxelarQueryAPI.ts
@@ -348,7 +348,7 @@ export class AxelarQueryAPI {
         toChainLimit = Number(toChainNexusResponse.limit);
       return Math.min(fromChainLimit, toChainLimit) * proportionOfTotalLimitPerTransfer;
     } catch (e) {
-      throw `could not parse response from ${fromChainId} for ${denom}`;
+      throw `could not fetch transfer limit for transfer from ${fromChainId} to ${toChainId} for ${denom}`;
     }
   }
 

--- a/src/libs/TransactionRecoveryApi/client/EVMClient/index.ts
+++ b/src/libs/TransactionRecoveryApi/client/EVMClient/index.ts
@@ -26,6 +26,10 @@ export default class EVMClient {
     return this.signer;
   }
 
+  public getProvivider() {
+    return this.provider;
+  }
+
   public async broadcastToGateway(gatewayAddress: string, opts: TransactionRequest) {
     const { data, maxFeePerGas, maxPriorityFeePerGas } = opts;
     const txRequest: TransactionRequest = {

--- a/src/libs/TransactionRecoveryApi/client/EVMClient/index.ts
+++ b/src/libs/TransactionRecoveryApi/client/EVMClient/index.ts
@@ -26,10 +26,6 @@ export default class EVMClient {
     return this.signer;
   }
 
-  public getProvivider() {
-    return this.provider;
-  }
-
   public async broadcastToGateway(gatewayAddress: string, opts: TransactionRequest) {
     const { data, maxFeePerGas, maxPriorityFeePerGas } = opts;
     const txRequest: TransactionRequest = {

--- a/src/libs/test/AxelarQueryAPI.spec.ts
+++ b/src/libs/test/AxelarQueryAPI.spec.ts
@@ -227,9 +227,9 @@ describe("AxelarQueryAPI", () => {
       const fromChainId = "ethereum-2";
       const toChainId = "sei";
       const denom = "uausdc";
-      const res: number = await api
+      const res: string = await api
         .getTransferLimit({ fromChainId, toChainId, denom })
-        .catch((e) => 0);
+        .catch((e) => "0");
       const expectedRes = 500_000_000 * 0.25;
       /**
        if we are sending from ethereum to sei, we expect res to be
@@ -241,7 +241,7 @@ describe("AxelarQueryAPI", () => {
        * 
        */
       expect(res).toBeDefined();
-      expect(res - expectedRes).toEqual(0);
+      expect(Number(res) - expectedRes).toEqual(0);
     });
   });
 });

--- a/src/libs/test/AxelarQueryAPI.spec.ts
+++ b/src/libs/test/AxelarQueryAPI.spec.ts
@@ -182,4 +182,25 @@ describe("AxelarQueryAPI", () => {
       });
     });
   });
+
+  describe("getTransferLimit", () => {
+    let api: AxelarQueryAPI;
+
+    beforeEach(async () => {
+      api = new AxelarQueryAPI({ environment: Environment.TESTNET });
+    });
+
+    test("it should return the transfer limit of an asset as a string for evm chains", async () => {
+      const chainId = "ethereum-2";
+      const denom = "uausdc";
+      const res = await api.getTransferLimit({ chainId, denom }).catch((e) => console.log(e));
+      expect(res).toBeDefined();
+    });
+    test("it should return the transfer limit of an asset as a string for axelarnet chains", async () => {
+      const chainId = "sei";
+      const denom = "uausdc";
+      const res = await api.getTransferLimit({ chainId, denom }).catch((e) => console.log(e));
+      expect(res).toBeDefined();
+    });
+  });
 });

--- a/src/libs/test/AxelarQueryAPI.spec.ts
+++ b/src/libs/test/AxelarQueryAPI.spec.ts
@@ -60,7 +60,7 @@ describe("AxelarQueryAPI", () => {
       ];
       expect(
         api.getTransferFee(sourceChainName, destinationChainName, assetDenom, amount)
-      ).rejects.toThrow("Invalid chain identifier for osmosis. Did you mean osmosis-4");
+      ).rejects.toThrow("Invalid chain identifier for osmosis. Did you mean osmosis-5");
     });
   });
 
@@ -228,18 +228,16 @@ describe("AxelarQueryAPI", () => {
       const fromChainId = "ethereum-2";
       const toChainId = "sei";
       const denom = "uausdc";
-      const proportionOfTotalLimitPerTransfer = 1;
       const res: number = await api
-        .getTransferLimit({ fromChainId, toChainId, denom, proportionOfTotalLimitPerTransfer })
+        .getTransferLimit({ fromChainId, toChainId, denom })
         .catch((e) => 0);
-      const expectedRes = 495_000_000;
+      const expectedRes = 500_000_000 * 0.25;
       /**
        if we are sending from ethereum to sei, we expect res to be
-       Math.min( ethereumLimit, seiLimit ) * proportion
-       = Math.min( ethereumLimit minus ethereumOutgoing, seiLimit minus seiIncoming ) * proportion
-       = Math.min ( 1000aUSDC minus 15aUSDC, 500aUSDC minus 5aUSDC) * 1
-       = Math.min (985aUSDC, 495aUSDC) * 1
-       = 495
+       Math.min( ethereumLimit, seiLimit )
+       = Math.min( ethereumLimit, seiLimit )
+       = Math.min ( 1000aUSDC, 500aUSDC)
+       = 500
        * 
        * 
        */

--- a/src/libs/test/AxelarQueryAPI.spec.ts
+++ b/src/libs/test/AxelarQueryAPI.spec.ts
@@ -3,7 +3,6 @@ import {
   TransferFeeResponse,
 } from "@axelar-network/axelarjs-types/axelar/nexus/v1beta1/query";
 import { ethers } from "ethers";
-import { formatUnits } from "ethers/lib/utils";
 import { CHAINS } from "../../chains";
 import { AxelarQueryAPI } from "../AxelarQueryAPI";
 import { Environment, EvmChain, GasToken } from "../types";
@@ -234,10 +233,10 @@ describe("AxelarQueryAPI", () => {
       const expectedRes = 500_000_000 * 0.25;
       /**
        if we are sending from ethereum to sei, we expect res to be
-       Math.min( ethereumLimit, seiLimit )
-       = Math.min( ethereumLimit, seiLimit )
-       = Math.min ( 1000aUSDC, 500aUSDC)
-       = 500
+       Math.min( ethereumLimit, seiLimit ) * 0.25 (0.25 represents default proportion of total limit)
+       = Math.min( ethereumLimit, seiLimit ) * 0.25 (0.25 represents default proportion of total limit)
+       = Math.min ( 1000aUSDC, 500aUSDC) * 0.25 (0.25 represents default proportion of total limit)
+       = 125
        * 
        * 
        */


### PR DESCRIPTION
adding method to `AxelarQueryAPI` called `getTransferLimit`
* for EVM chains, query directly to the gateway contract for `tokenMintLimit`
* for cosmos chains, query the nexus module


a user would invoke in the following way:


```ts
const config: AxelarQueryAPIConfig = {
  environment: Environment.MAINNET,
};

const api = new AxelarQueryAPI(config);

const testEVM = async () => {
  const chainId = "ethereum";
  const denom = "uusdc";
  const res = await api
    .getTransferLimit({ chainId, denom })
    .catch((e) => console.log(e));
  console.log("res", res);
};

const testCosmos = async () => {
  const chainId = "osmosis";
  const denom = "uusdc";
  const res = await api
    .getTransferLimit({ chainId, denom })
    .catch((e) => console.log(e));
  console.log("res", res);
};

testEVM();
testCosmos();
```