### PR TITLE
chore: convert native token to erc in axelar query

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@axelar-network/axelarjs-sdk",
-  "version": "0.12.0-alpha.12",
+  "version": "0.12.0-alpha.13",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@axelar-network/axelarjs-sdk",
-      "version": "0.12.0-alpha.12",
+      "version": "0.12.0-alpha.13",
       "license": "MIT",
       "dependencies": {
         "@axelar-network/axelar-cgp-solidity": "^4.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@axelar-network/axelarjs-sdk",
-  "version": "0.12.0-alpha.13",
+  "version": "0.12.0-alpha.14",
   "description": "The JavaScript SDK for Axelar Network",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@axelar-network/axelarjs-sdk",
-  "version": "0.12.0-alpha.12",
+  "version": "0.12.0-alpha.13",
   "description": "The JavaScript SDK for Axelar Network",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",

--- a/src/assets/types/index.ts
+++ b/src/assets/types/index.ts
@@ -19,11 +19,14 @@ export interface AssetInfoForChain extends AssetInfo {
 }
 
 export interface AssetConfig {
+  id: string;
   common_key: { [env: string]: string };
   native_chain: string;
   fully_supported: boolean;
   decimals: number;
   chain_aliases: { [key: string]: AssetInfoForChain };
+  wrapped_erc20: string;
+  is_gas_token: boolean;
 }
 
 export type LoadAssetConfig = {

--- a/src/libs/AxelarQueryAPI.ts
+++ b/src/libs/AxelarQueryAPI.ts
@@ -382,13 +382,6 @@ export class AxelarQueryAPI {
     const chain = chains.find((c) => c.id === chainId);
     if (!chain) throw `Chain ${chainId} not found`;
 
-    // verify asset params
-    if (!this.allAssets) await this._initializeAssets();
-    const assetConfig = this.allAssets.find(
-      (asset) => asset.common_key[this.environment] === denom.toLowerCase()
-    );
-    if (!assetConfig) throw `Asset ${denom} not found`;
-
     const api: AxelarQueryClientType = await AxelarQueryClient.initOrGetAxelarQueryClient({
       environment: this.environment,
     });

--- a/src/libs/AxelarQueryAPI.ts
+++ b/src/libs/AxelarQueryAPI.ts
@@ -386,12 +386,11 @@ export class AxelarQueryAPI {
       environment: this.environment,
     });
 
+    const asset = await this._convertAssetDenom(denom);
+
     try {
       // the "limit" response to the TransferRateLimit RPC query is of type Uint8Array, so need to decode it
-      const res = await api.nexus.TransferRateLimit({
-        chain: chainId,
-        asset: await this._convertAssetDenom(denom),
-      });
+      const res = await api.nexus.TransferRateLimit({ chain: chainId, asset });
       const { transferRateLimit } = res;
       if (
         !transferRateLimit ||


### PR DESCRIPTION
* now that we are supporting native assets, users will likely make requests to AxelarQueryApi with assets like "ETH"/"AVAX"/etc.
* this network level query will not work, but the response params will be the same as their corresponding wrapped equivalents, i.e. "weth-wei"/"wavax-wei"/etc. 
* wanted to get your thoughts on the following conversion function in this PR. thoughts?