### PR TITLE
chore: add `gasLimitBuffer` to execute function

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@axelar-network/axelarjs-sdk",
-  "version": "0.12.3",
+  "version": "0.12.4-alpha.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@axelar-network/axelarjs-sdk",
-      "version": "0.12.3",
+      "version": "0.12.4-alpha.0",
       "license": "MIT",
       "dependencies": {
         "@axelar-network/axelar-cgp-solidity": "^4.3.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -6010,7 +6010,6 @@
       "resolved": "https://registry.npmjs.org/bufferutil/-/bufferutil-4.0.5.tgz",
       "integrity": "sha512-HTm14iMQKK2FjFLRTM5lAVcyaUzOnqbPtesFIvREgXpJHdQm8bWS+GkQgIkfaBYRHuCnea7w8UVNfwiAQhlr9A==",
       "dev": true,
-      "hasInstallScript": true,
       "optional": true,
       "dependencies": {
         "node-gyp-build": "^4.3.0"
@@ -6373,7 +6372,6 @@
       "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.7.tgz",
       "integrity": "sha512-vLt1O5Pp+flcArHGIyKEQq883nBt8nN8tVBcoL0qUXj2XT1n7p70yGIq2VK98I5FdZ1YHc0wk/koOnHjnXWk1Q==",
       "dev": true,
-      "hasInstallScript": true,
       "optional": true,
       "dependencies": {
         "node-gyp-build": "^4.3.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@axelar-network/axelarjs-sdk",
-  "version": "0.12.3",
+  "version": "0.12.4-alpha.0",
   "description": "The JavaScript SDK for Axelar Network",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",

--- a/src/libs/TransactionRecoveryApi/AxelarGMPRecoveryAPI.ts
+++ b/src/libs/TransactionRecoveryApi/AxelarGMPRecoveryAPI.ts
@@ -395,12 +395,13 @@ export class AxelarGMPRecoveryAPI extends AxelarRecoveryApi {
     if (response?.status !== GMPStatus.DEST_GATEWAY_APPROVED) return NotApprovedError();
 
     const executeParams = response.data as ExecuteParams;
+    const gasLimitBuffer = evmWalletDetails?.gasLimitBuffer || 0;
     const { destinationChain, destinationContractAddress } = executeParams;
 
     const signer = this.getSigner(destinationChain, evmWalletDetails);
     const contract = new ethers.Contract(destinationContractAddress, IAxelarExecutable.abi, signer);
 
-    const txResult: TxResult = await callExecute(executeParams, contract)
+    const txResult: TxResult = await callExecute(executeParams, contract, gasLimitBuffer)
       .then((tx: ContractReceipt) => {
         const {
           commandId,

--- a/src/libs/TransactionRecoveryApi/helpers/contractCallHelper.ts
+++ b/src/libs/TransactionRecoveryApi/helpers/contractCallHelper.ts
@@ -8,7 +8,8 @@ export enum CALL_EXECUTE_ERROR {
 
 export async function callExecute(
   params: ExecuteParams,
-  contract: Contract
+  contract: Contract,
+  gasLimitBuffer = 0
 ): Promise<ContractReceipt> {
   const {
     commandId,
@@ -29,7 +30,9 @@ export async function callExecute(
     if (!estimatedGas) throw new Error(CALL_EXECUTE_ERROR.REVERT);
 
     txReceipt = contract
-      .executeWithToken(commandId, sourceChain, sourceAddress, payload, symbol, amount)
+      .executeWithToken(commandId, sourceChain, sourceAddress, payload, symbol, amount, {
+        gasLimit: estimatedGas.add(gasLimitBuffer),
+      })
       .then((tx: ContractTransaction) => tx.wait())
       .catch(() => undefined);
   } else {
@@ -40,7 +43,9 @@ export async function callExecute(
     if (!estimatedGas) throw new Error(CALL_EXECUTE_ERROR.REVERT);
 
     txReceipt = contract
-      .execute(commandId, sourceChain, sourceAddress, payload)
+      .execute(commandId, sourceChain, sourceAddress, payload, {
+        gasLimit: estimatedGas.add(gasLimitBuffer),
+      })
       .then((tx: ContractTransaction) => tx.wait())
       .catch(() => undefined);
   }

--- a/src/libs/test/TransactionRecoveryAPI/helper/contractCallHelper.spec.ts
+++ b/src/libs/test/TransactionRecoveryAPI/helper/contractCallHelper.spec.ts
@@ -21,10 +21,12 @@ describe("contractCallHelper", () => {
       const mockExecuteWithToken = vitest.fn().mockResolvedValueOnce({ wait: mockWait });
       const contract: any = {
         executeWithToken: mockExecuteWithToken,
-        estimateGas: { executeWithToken: vitest.fn().mockResolvedValueOnce(1) },
+        estimateGas: {
+          executeWithToken: vitest.fn().mockResolvedValueOnce(ethers.BigNumber.from(100000)),
+        },
       };
 
-      await callExecute(stub, contract);
+      await callExecute(stub, contract, 100000);
 
       expect(mockExecuteWithToken).toHaveBeenCalledWith(
         stub.commandId,
@@ -32,7 +34,10 @@ describe("contractCallHelper", () => {
         stub.sourceAddress,
         stub.payload,
         stub.symbol,
-        stub.amount
+        stub.amount,
+        {
+          gasLimit: ethers.BigNumber.from(200000),
+        }
       );
       expect(mockWait).toBeCalledTimes(1);
     });

--- a/src/libs/test/TransactionRecoveryAPI/helper/contractCallHelper.spec.ts
+++ b/src/libs/test/TransactionRecoveryAPI/helper/contractCallHelper.spec.ts
@@ -4,10 +4,11 @@ import { EvmChain } from "../../../types";
 import IAxelarExecutable from "../../../abi/IAxelarExecutable";
 import { ethers, Wallet } from "ethers";
 import { fork } from "../../testUtils/localChain";
+import type { Mock } from "vitest";
 
 describe("contractCallHelper", () => {
   describe("callExecute", () => {
-    let mockWait: vitest.Mock<any, any>;
+    let mockWait: Mock<any, any>;
     const stub = executeParamsStub();
 
     beforeEach(() => {

--- a/src/libs/types/index.ts
+++ b/src/libs/types/index.ts
@@ -94,6 +94,7 @@ export type EvmWalletDetails = {
   privateKey?: string;
   useWindowEthereum?: boolean;
   provider?: ethers.providers.JsonRpcProvider;
+  gasLimitBuffer?: number;
 };
 export interface AxelarQueryClientConfig {
   axelarRpcUrl?: string;


### PR DESCRIPTION
# Description

This PR accepts `evmWalletDetails.gasLimitBuffer` for the `execute` function. `gasLimitBuffer` will be added to the gas estimated value before sending `executeWithToken` or `execute` tx. The default value for `gasLimitBuffer` is 0