### PR TITLE
feat:add repo to package.json for link on npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,10 @@
   "name": "@axelar-network/axelarjs-sdk",
   "version": "0.12.4",
   "description": "The JavaScript SDK for Axelar Network",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/axelarnetwork/axelarjs-sdk"
+  },
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
   "files": [


### PR DESCRIPTION
Hopefully adding a repository link here will get the "repository" link to show up on npm here:  https://www.npmjs.com/package/@axelar-network/axelarjs-sdk/