### PR TITLE
chore: adding a fix to addNativeGasMethod with overestimation

### DIFF
--- a/src/libs/TransactionRecoveryApi/AxelarRecoveryApi.ts
+++ b/src/libs/TransactionRecoveryApi/AxelarRecoveryApi.ts
@@ -189,7 +189,7 @@ export class AxelarRecoveryApi {
     );
   }
 
-  private parseGMPStatus(response: any): GMPStatus | string {
+  public parseGMPStatus(response: any): GMPStatus | string {
     const { error, status } = response;
 
     if (status === "error" && error) return GMPStatus.DEST_EXECUTE_ERROR;

--- a/src/libs/TransactionRecoveryApi/AxelarRecoveryApi.ts
+++ b/src/libs/TransactionRecoveryApi/AxelarRecoveryApi.ts
@@ -27,6 +27,7 @@ export enum GMPStatus {
   INSUFFICIENT_FEE = "insufficient_fee",
   UNKNOWN_ERROR = "unknown_error",
   CANNOT_FETCH_STATUS = "cannot_fetch_status",
+  SRC_GATEWAY_CONFIRMED = "confirmed",
 }
 
 export enum GasPaidStatus {

--- a/src/libs/types/index.ts
+++ b/src/libs/types/index.ts
@@ -144,6 +144,7 @@ export interface AddGasOptions {
   amount?: string;
   refundAddress?: string;
   estimatedGasUsed?: number;
+  gasMultipler?: number;
   evmWalletDetails?: EvmWalletDetails;
 }
 
@@ -176,6 +177,8 @@ export interface TxResult {
 export interface QueryGasFeeOptions {
   provider?: ethers.providers.JsonRpcProvider;
   estimatedGas?: number;
+  gasMultipler?: number;
+  shouldSubtractBaseFee?: boolean;
 }
 
 export interface QueryTransferOptions {


### PR DESCRIPTION
two things: 
1. the `addNativeGas` method should accept additional parameters to allow the invoker to specify what gas amount and gas multiple to use
2. the implementation of `addNativeGas`, which calls `subtractGasFee`, should subtract the base fee if the transaction has already been confirmed. (as per #239)