### PR TITLE
chore: throw error instead of returning 0 in estimateGasFee

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   - Fix `queryTransactionStatus` method to accept cosmos-based source chains
 - AxelarQueryAPI
   - Fix `estimateGasFee` method to allow for cosmos source chains, including adjustments to the way in which the numbers are calculated after swapping between currencies with different decimals
+  - Fix: throw error instead of returning 0 in estimateGasFee
   - Update `GMPParams` in `estimateGasFee` method to accept `amountInUnits`
 - AxelarGMPRecoveryAPI
   - update the delay after transaction confirmation to 60 seconds before it finds the confirmed event on the axelar network (from 30 seconds originally)

--- a/src/libs/AxelarQueryAPI.ts
+++ b/src/libs/AxelarQueryAPI.ts
@@ -206,39 +206,33 @@ export class AxelarQueryAPI {
       params.amountInUnits = amountInUnits;
     }
 
-    return this.axelarGMPServiceApi
-      .post("", params)
-      .then((response) => {
-        const {
-          source_base_fee_string,
-          source_token,
-          destination_native_token,
-          express_fee_string,
-          express_supported,
-        } = response.result;
-        const { decimals: sourceTokenDecimals } = source_token;
-        const baseFee = parseUnits(source_base_fee_string, sourceTokenDecimals).toString();
-        const expressFee = express_fee_string
-          ? parseUnits(express_fee_string, sourceTokenDecimals).toString()
-          : "0";
-        return {
-          baseFee,
-          expressFee,
-          sourceToken: source_token,
-          destToken: {
-            gas_price: destination_native_token.gas_price,
-            gas_price_gwei: parseInt(destination_native_token.gas_price_gwei).toString(),
-            decimals: destination_native_token.decimals,
-          },
-          apiResponse: response,
-          success: true,
-          expressSupported: express_supported,
-        };
-      })
-      .catch((e) => {
-        console.error("some kind of issue", e);
-        return {} as any;
-      });
+    return this.axelarGMPServiceApi.post("", params).then((response) => {
+      const {
+        source_base_fee_string,
+        source_token,
+        destination_native_token,
+        express_fee_string,
+        express_supported,
+      } = response.result;
+      const { decimals: sourceTokenDecimals } = source_token;
+      const baseFee = parseUnits(source_base_fee_string, sourceTokenDecimals).toString();
+      const expressFee = express_fee_string
+        ? parseUnits(express_fee_string, sourceTokenDecimals).toString()
+        : "0";
+      return {
+        baseFee,
+        expressFee,
+        sourceToken: source_token,
+        destToken: {
+          gas_price: destination_native_token.gas_price,
+          gas_price_gwei: parseInt(destination_native_token.gas_price_gwei).toString(),
+          decimals: destination_native_token.decimals,
+        },
+        apiResponse: response,
+        success: true,
+        expressSupported: express_supported,
+      };
+    });
   }
 
   /**
@@ -272,14 +266,14 @@ export class AxelarQueryAPI {
       gmpParams?.sourceContractAddress,
       gmpParams?.transferAmount,
       gmpParams?.transferAmountInUnits
-    ).catch(() => undefined);
-
-    if (!response) return "0";
+    );
 
     const { baseFee, expressFee, sourceToken, destToken, apiResponse, success, expressSupported } =
       response;
 
-    if (!success || !baseFee || !sourceToken) return "0";
+    if (!success || !baseFee || !sourceToken) {
+      throw new Error("Failed to estimate gas fee");
+    }
 
     const destGasFeeWei = parseUnits(
       (gasLimit * Number(destToken.gas_price)).toFixed(destToken.decimals),


### PR DESCRIPTION
# Overview
This PR improves the `estimateGasFee` API to throw an error when an error occurs during an internal function call. Currently, the API returns 0, which makes it difficult for the caller to handle unexpected data.

# Changes Made
Previously, if an error occurred during an internal function call, the `estimateGasFee` API would return 0, which could be misinterpreted as a valid gas fee of zero. This PR changes the behavior of the API to throw an error if occurs.

# Example
Before this change, if an error occurred during an internal function call, the estimateGasFee API might return:

```
0
```

After this change, the `estimateGasFee` API will throw an error with the message `Failed to estimate gas fee` if it is an unknown error or an error that propagates from the `getNativeGasBaseFee` function.

This change makes it easier for callers to handle unexpected data and avoids the need for non-standard error handling code.