### PR TITLE
chore: fix manualRelayToDestChain

### DIFF
--- a/.github/workflows/release-alpha.yml
+++ b/.github/workflows/release-alpha.yml
@@ -18,6 +18,7 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: 18
+          registry-url: "https://registry.npmjs.org"
 
       - name: Install pnpm
         uses: pnpm/action-setup@v2

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@axelar-network/axelarjs-sdk",
-  "version": "0.13.5",
+  "version": "0.13.6-alpha.1",
   "description": "The JavaScript SDK for Axelar Network",
   "repository": {
     "type": "git",

--- a/src/libs/AxelarQueryAPI.ts
+++ b/src/libs/AxelarQueryAPI.ts
@@ -98,10 +98,12 @@ export class AxelarQueryAPI {
   public async getEVMEvent(sourceChainId: string, srcTxHash: string, srcEventId: number) {
     await throwIfInvalidChainIds([sourceChainId], this.environment);
     await this.initQueryClientIfNeeded();
-    return this.axelarQueryClient.evm.Event({
-      chain: sourceChainId,
-      eventId: `${srcTxHash}-${srcEventId}`,
-    });
+    return this.axelarQueryClient.evm
+      .Event({
+        chain: sourceChainId,
+        eventId: `${srcTxHash}-${srcEventId}`,
+      })
+      .catch(() => undefined);
   }
 
   public async getConfirmationHeight(chain: string) {

--- a/src/libs/TransactionRecoveryApi/AxelarGMPRecoveryAPI.ts
+++ b/src/libs/TransactionRecoveryApi/AxelarGMPRecoveryAPI.ts
@@ -298,7 +298,7 @@ export class AxelarGMPRecoveryAPI extends AxelarRecoveryApi {
   ): Promise<SignTxSDKResponse> {
     let signTxLog = "";
     try {
-      const batchData = await this.fetchBatchData(destChainId, commandId);
+      const batchData = await retry(() => this.fetchBatchData(destChainId, commandId), 10, 3000);
       if (batchData) {
         signTxLog = `signing: batch data exists so do not need to sign. commandId: ${commandId}, batchId: ${batchData.batch_id}`;
         if (this.debugMode) console.debug(signTxLog);

--- a/src/libs/TransactionRecoveryApi/AxelarGMPRecoveryAPI.ts
+++ b/src/libs/TransactionRecoveryApi/AxelarGMPRecoveryAPI.ts
@@ -895,7 +895,10 @@ export class AxelarGMPRecoveryAPI extends AxelarRecoveryApi {
     const gasLimitBuffer = evmWalletDetails?.gasLimitBuffer || 0;
     const { destinationChain, destinationContractAddress } = executeParams;
 
-    const signer = this.getSigner(destinationChain, evmWalletDetails);
+    const signer = this.getSigner(
+      destinationChain,
+      evmWalletDetails || { useWindowEthereum: true }
+    );
     const contract = new ethers.Contract(destinationContractAddress, IAxelarExecutable.abi, signer);
 
     const txResult: TxResult = await callExecute(executeParams, contract, gasLimitBuffer)

--- a/src/libs/TransactionRecoveryApi/constants/chain/testnet.ts
+++ b/src/libs/TransactionRecoveryApi/constants/chain/testnet.ts
@@ -69,7 +69,7 @@ export const networkInfo: Record<EvmChain | string, Network> = {
     name: EvmChain.BASE,
   },
   [EvmChain.FILECOIN]: {
-    chainId: 3141,
+    chainId: 314159,
     name: EvmChain.FILECOIN,
   },
   [EvmChain.OPTIMISM]: {

--- a/src/libs/TransactionRecoveryApi/constants/chain/testnet.ts
+++ b/src/libs/TransactionRecoveryApi/constants/chain/testnet.ts
@@ -14,7 +14,7 @@ export const rpcMap: Record<EvmChain | string, string> = {
   [EvmChain.CELO]: "https://alfajores-forno.celo-testnet.org",
   [EvmChain.KAVA]: "https://evm.testnet.kava.io",
   [EvmChain.BASE]: "https://goerli.base.org",
-  [EvmChain.FILECOIN]: "https://rpc.ankr.com/filecoin_testnet",
+  [EvmChain.FILECOIN]: "https://filecoin-calibration.chainup.net/rpc/v1",
   [EvmChain.OPTIMISM]: "https://goerli.optimism.io",
   [EvmChain.LINEA]: "https://rpc.goerli.linea.build",
 };

--- a/src/libs/test/TransactionRecoveryAPI/AxelarGMPRecoveryAPI.spec.ts
+++ b/src/libs/test/TransactionRecoveryAPI/AxelarGMPRecoveryAPI.spec.ts
@@ -82,15 +82,9 @@ describe("AxelarGMPRecoveryAPI", () => {
       const response = await api.findEventAndConfirmIfNeeded(
         EvmChain.AVALANCHE,
         EvmChain.POLYGON,
-        txHash,
-        evmWalletDetails
+        txHash
       );
-      expect(mockEvmEvent).toHaveBeenCalledWith(
-        EvmChain.AVALANCHE,
-        EvmChain.POLYGON,
-        txHash,
-        evmWalletDetails
-      );
+      expect(mockEvmEvent).toHaveBeenCalledWith(EvmChain.AVALANCHE, EvmChain.POLYGON, txHash);
       expect(mockConfirmGatewayTx).toHaveBeenCalledWith(txHash, EvmChain.AVALANCHE);
       expect(mockDoesTxMeetConfirmHt).toHaveBeenCalledWith(EvmChain.AVALANCHE, txHash);
       expect(response).toBeDefined();
@@ -118,8 +112,7 @@ describe("AxelarGMPRecoveryAPI", () => {
       const response = await api.findEventAndConfirmIfNeeded(
         EvmChain.AVALANCHE,
         EvmChain.POLYGON,
-        "0xf452bc47fff8962190e114d0e1f7f3775327f6a5d643ca4fd5d39e9415e54503",
-        evmWalletDetails
+        "0xf452bc47fff8962190e114d0e1f7f3775327f6a5d643ca4fd5d39e9415e54503"
       );
 
       expect(mockConfirmGatewayTx).not.toHaveBeenCalled();
@@ -152,8 +145,7 @@ describe("AxelarGMPRecoveryAPI", () => {
       const response = await api.findEventAndConfirmIfNeeded(
         EvmChain.AVALANCHE,
         EvmChain.POLYGON,
-        txHash,
-        evmWalletDetails
+        txHash
       );
 
       expect(mockConfirmGatewayTx).toBeCalledTimes(0);
@@ -184,8 +176,7 @@ describe("AxelarGMPRecoveryAPI", () => {
       const response = await api.findEventAndConfirmIfNeeded(
         EvmChain.AVALANCHE,
         EvmChain.POLYGON,
-        txHash,
-        evmWalletDetails
+        txHash
       );
 
       expect(mockConfirmGatewayTx).toHaveBeenCalledWith(txHash, EvmChain.AVALANCHE);

--- a/src/libs/test/TransactionRecoveryAPI/EncodingTests.spec.ts
+++ b/src/libs/test/TransactionRecoveryAPI/EncodingTests.spec.ts
@@ -28,11 +28,7 @@ describe("AxelarDepositRecoveryAPI", () => {
     const api = new AxelarGMPRecoveryAPI({ environment: Environment.TESTNET });
     test("It should create a command ID from a tx hash and event index", async () => {
       const txHash = "0x2c9083bebd1f82b86b7b0d3298885f90767b584742df9ec3a9c9f15872a1fff9";
-      const eventIndex = await api.getEventIndex(
-        "ethereum-2" as EvmChain,
-        txHash,
-        evmWalletDetails
-      );
+      const eventIndex = await api.getEventIndex("ethereum-2" as EvmChain, txHash);
       const res = await api.getCidFromSrcTxHash(EvmChain.MOONBEAM, txHash, eventIndex as number);
       console.log("eventIndex", eventIndex);
       console.log("res", res);


### PR DESCRIPTION
Fix the issue with `manualRelayToDestChain` where the web client incorrectly utilizes the provider from the injected browser wallet instead of the rpcUrl embedded in the SDK. This error arises when the injected wallet's network differs from the source chain.