### PR TITLE
chore: adding optional parameter for log index to recovery methods

### DIFF
--- a/src/libs/TransactionRecoveryApi/AxelarRecoveryApi.ts
+++ b/src/libs/TransactionRecoveryApi/AxelarRecoveryApi.ts
@@ -139,7 +139,7 @@ export class AxelarRecoveryApi {
     this.config = config;
   }
 
-  public async fetchGMPTransaction(txHash: string, txLogIndex?: number | null) {
+  public async fetchGMPTransaction(txHash: string, txLogIndex?: number | undefined) {
     return this.execGet(this.axelarGMPApiUrl, {
       method: "searchGMP",
       txHash,
@@ -218,7 +218,7 @@ export class AxelarRecoveryApi {
 
   public async queryTransactionStatus(
     txHash: string,
-    txLogIndex?: number | null
+    txLogIndex?: number | undefined
   ): Promise<GMPStatusResponse> {
     const txDetails = await this.fetchGMPTransaction(txHash, txLogIndex);
 

--- a/src/libs/TransactionRecoveryApi/AxelarRecoveryApi.ts
+++ b/src/libs/TransactionRecoveryApi/AxelarRecoveryApi.ts
@@ -139,7 +139,7 @@ export class AxelarRecoveryApi {
     this.config = config;
   }
 
-  public async fetchGMPTransaction(txHash: string, txLogIndex?: number) {
+  public async fetchGMPTransaction(txHash: string, txLogIndex?: number | null) {
     return this.execGet(this.axelarGMPApiUrl, {
       method: "searchGMP",
       txHash,
@@ -216,8 +216,11 @@ export class AxelarRecoveryApi {
     }
   }
 
-  public async queryTransactionStatus(txHash: string): Promise<GMPStatusResponse> {
-    const txDetails = await this.fetchGMPTransaction(txHash);
+  public async queryTransactionStatus(
+    txHash: string,
+    txLogIndex?: number | null
+  ): Promise<GMPStatusResponse> {
+    const txDetails = await this.fetchGMPTransaction(txHash, txLogIndex);
 
     if (!txDetails) return { status: GMPStatus.CANNOT_FETCH_STATUS };
 

--- a/src/libs/test/TransactionRecoveryAPI/AxelarGMPRecoveryAPI.spec.ts
+++ b/src/libs/test/TransactionRecoveryAPI/AxelarGMPRecoveryAPI.spec.ts
@@ -83,6 +83,7 @@ describe("AxelarGMPRecoveryAPI", () => {
         EvmChain.AVALANCHE,
         EvmChain.POLYGON,
         txHash,
+        undefined,
         evmWalletDetails
       );
       expect(mockEvmEvent).toHaveBeenCalledWith(
@@ -119,6 +120,7 @@ describe("AxelarGMPRecoveryAPI", () => {
         EvmChain.AVALANCHE,
         EvmChain.POLYGON,
         "0xf452bc47fff8962190e114d0e1f7f3775327f6a5d643ca4fd5d39e9415e54503",
+        undefined,
         evmWalletDetails
       );
 
@@ -153,6 +155,7 @@ describe("AxelarGMPRecoveryAPI", () => {
         EvmChain.AVALANCHE,
         EvmChain.POLYGON,
         txHash,
+        undefined,
         evmWalletDetails
       );
 
@@ -185,6 +188,7 @@ describe("AxelarGMPRecoveryAPI", () => {
         EvmChain.AVALANCHE,
         EvmChain.POLYGON,
         txHash,
+        undefined,
         evmWalletDetails
       );
 
@@ -590,7 +594,7 @@ describe("AxelarGMPRecoveryAPI", () => {
       const mockGetEvmEvent = vitest.spyOn(api, "getEvmEvent");
       mockGetEvmEvent.mockResolvedValueOnce(evmEventStubResponse());
 
-      const res = await api.manualRelayToDestChain("0x", undefined, false);
+      const res = await api.manualRelayToDestChain("0x", undefined, undefined, false);
       expect(res).toBeTruthy();
       expect(res?.success).toBeFalsy();
       expect(res?.error).toEqual(
@@ -633,7 +637,7 @@ describe("AxelarGMPRecoveryAPI", () => {
       const mockGetEvmEvent = vitest.spyOn(api, "getEvmEvent");
       mockGetEvmEvent.mockResolvedValueOnce(evmEventStubResponse());
 
-      const res = await api.manualRelayToDestChain("0x", undefined, false);
+      const res = await api.manualRelayToDestChain("0x", undefined, undefined, false);
       expect(res).toBeTruthy();
       expect(res?.success).toBeFalsy();
       expect(res?.error).toEqual(`findBatchAndApproveGateway(): unable to retrieve command ID`);
@@ -661,7 +665,7 @@ describe("AxelarGMPRecoveryAPI", () => {
           infoLogs: ["log"],
         });
 
-      const response = await api.manualRelayToDestChain("0x", undefined, false);
+      const response = await api.manualRelayToDestChain("0x", undefined, undefined, false);
       expect(mockFindEventAndConfirmIfNeeded).toHaveBeenCalled();
       expect(mockSignAndApproveGateway).toHaveBeenCalled();
       expect(response.success).toBeTruthy();

--- a/src/libs/test/TransactionRecoveryAPI/EncodingTests.spec.ts
+++ b/src/libs/test/TransactionRecoveryAPI/EncodingTests.spec.ts
@@ -19,7 +19,7 @@ describe("AxelarDepositRecoveryAPI", () => {
     const api = new AxelarGMPRecoveryAPI({ environment: Environment.TESTNET });
     test("It should create a command ID from a tx hash and event index", async () => {
       const txHash = "0x0a83f6bff1697bb1f72ee60713427e802f32571f042abfa7c6278024f440e861";
-      const res = await api.manualRelayToDestChain(txHash, evmWalletDetails);
+      const res = await api.manualRelayToDestChain(txHash, undefined, evmWalletDetails);
       expect(res).toBeTruthy();
     }, 120000);
   });
@@ -43,7 +43,7 @@ describe("AxelarDepositRecoveryAPI", () => {
     const api = new AxelarGMPRecoveryAPI({ environment: Environment.TESTNET });
     test("fetching event status", async () => {
       const txHash = "0xa290f800f2089535a0abb013cea9cb26e1cdb3f2a2f2a8dcef2f149eb7a4d3be";
-      const event = await api.getEvmEvent(EvmChain.MOONBEAM, EvmChain.POLYGON, txHash);
+      const event = await api.getEvmEvent(EvmChain.MOONBEAM, EvmChain.POLYGON, txHash, undefined);
       console.log("event", event);
       const res = await api.isEVMEventCompleted(event.eventResponse);
       expect(res).toBeTruthy();


### PR DESCRIPTION
* adding optional parameter to `manualRelayToDestinationChain` method to accept tx log index. builds upon #285 