### PR TITLE
chore: add event index as an optional parameter and fixing filecoin rpc

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@axelar-network/axelarjs-sdk",
-  "version": "0.13.7-alpha.6",
+  "version": "0.13.7-alpha.7",
   "description": "The JavaScript SDK for Axelar Network",
   "repository": {
     "type": "git",

--- a/src/libs/TransactionRecoveryApi/AxelarGMPRecoveryAPI.ts
+++ b/src/libs/TransactionRecoveryApi/AxelarGMPRecoveryAPI.ts
@@ -246,7 +246,7 @@ export class AxelarGMPRecoveryAPI extends AxelarRecoveryApi {
     infoLog: string;
   }> {
     const eventIndex =
-      srcTxEventIndex ||
+      srcTxEventIndex ??
       (await this.getEventIndex(srcChainId, srcTxHash)
         .then((index) => index as number)
         .catch(() => -1));
@@ -471,7 +471,7 @@ export class AxelarGMPRecoveryAPI extends AxelarRecoveryApi {
       };
     const srcChain: string = callTx.chain;
     const destChain: string = callTx.returnValues.destinationChain;
-    const eventIndex = txEventIndex ?? callTx._id;
+    const eventIndex = txEventIndex ?? callTx._logIndex;
     const srcChainInfo = await this.getChainInfo(srcChain);
     const destChainInfo = await this.getChainInfo(destChain);
     const routeDir = this.getRouteDir(srcChainInfo, destChainInfo);
@@ -532,7 +532,7 @@ export class AxelarGMPRecoveryAPI extends AxelarRecoveryApi {
     const payload = await this.fetchGMPTransaction(txHash).then(
       (data) => data.call.returnValues.payload
     );
-    const eventIndex = txEventIndex || (await this.getEventIndex(srcChain as EvmChain, txHash));
+    const eventIndex = txEventIndex ?? (await this.getEventIndex(srcChain as EvmChain, txHash));
 
     // Send the route message tx
     const routeMessageTx = await this.routeMessageRequest(txHash, payload, eventIndex).catch(
@@ -932,7 +932,7 @@ export class AxelarGMPRecoveryAPI extends AxelarRecoveryApi {
     if (!receipt) return InvalidTransactionError(chain);
 
     const destinationChain = options?.destChain || getDestinationChainFromTxReceipt(receipt);
-    const logIndex = options?.logIndex || getLogIndexFromTxReceipt(receipt);
+    const logIndex = options?.logIndex ?? getLogIndexFromTxReceipt(receipt);
 
     // Check if given txHash is valid
     if (!destinationChain) return NotGMPTransactionError();
@@ -1019,7 +1019,7 @@ export class AxelarGMPRecoveryAPI extends AxelarRecoveryApi {
     if (!receipt) return InvalidTransactionError(chain);
 
     const destinationChain = options?.destChain || getDestinationChainFromTxReceipt(receipt);
-    const logIndex = options?.logIndex || getLogIndexFromTxReceipt(receipt);
+    const logIndex = options?.logIndex ?? getLogIndexFromTxReceipt(receipt);
 
     // Check if given txHash is valid
     if (!destinationChain) return NotGMPTransactionError();

--- a/src/libs/TransactionRecoveryApi/constants/chain/testnet.ts
+++ b/src/libs/TransactionRecoveryApi/constants/chain/testnet.ts
@@ -14,7 +14,7 @@ export const rpcMap: Record<EvmChain | string, string> = {
   [EvmChain.CELO]: "https://alfajores-forno.celo-testnet.org",
   [EvmChain.KAVA]: "https://evm.testnet.kava.io",
   [EvmChain.BASE]: "https://goerli.base.org",
-  "filecoin-2": "https://filecoin-calibration.chainup.net/rpc/v1",
+  "filecoin-2": "https://rpc.ankr.com/filecoin_testnet",
   [EvmChain.OPTIMISM]: "https://goerli.optimism.io",
   [EvmChain.LINEA]: "https://rpc.goerli.linea.build",
   [EvmChain.POLYGON_ZKEVM]: "https://testnet-zkevm.polygonscan.com",

--- a/src/libs/test/TransactionRecoveryAPI/AxelarGMPRecoveryAPI.spec.ts
+++ b/src/libs/test/TransactionRecoveryAPI/AxelarGMPRecoveryAPI.spec.ts
@@ -600,7 +600,7 @@ describe("AxelarGMPRecoveryAPI", () => {
       const mockGetEvmEvent = vitest.spyOn(api, "getEvmEvent");
       mockGetEvmEvent.mockResolvedValueOnce(evmEventStubResponse());
 
-      const res = await api.manualRelayToDestChain("0x", undefined, undefined, false);
+      const res = await api.manualRelayToDestChain("0x", undefined, undefined, undefined, false);
       expect(res).toBeTruthy();
       expect(res?.success).toBeFalsy();
       expect(res?.error).toEqual(
@@ -643,7 +643,7 @@ describe("AxelarGMPRecoveryAPI", () => {
       const mockGetEvmEvent = vitest.spyOn(api, "getEvmEvent");
       mockGetEvmEvent.mockResolvedValueOnce(evmEventStubResponse());
 
-      const res = await api.manualRelayToDestChain("0x", undefined, undefined, false);
+      const res = await api.manualRelayToDestChain("0x", undefined, undefined, undefined, false);
       expect(res).toBeTruthy();
       expect(res?.success).toBeFalsy();
       expect(res?.error).toEqual(`findBatchAndApproveGateway(): unable to retrieve command ID`);
@@ -671,7 +671,13 @@ describe("AxelarGMPRecoveryAPI", () => {
           infoLogs: ["log"],
         });
 
-      const response = await api.manualRelayToDestChain("0x", undefined, undefined, false);
+      const response = await api.manualRelayToDestChain(
+        "0x",
+        undefined,
+        undefined,
+        undefined,
+        false
+      );
       expect(mockFindEventAndConfirmIfNeeded).toHaveBeenCalled();
       expect(mockSignAndApproveGateway).toHaveBeenCalled();
       expect(response.success).toBeTruthy();

--- a/src/libs/test/TransactionRecoveryAPI/EncodingTests.spec.ts
+++ b/src/libs/test/TransactionRecoveryAPI/EncodingTests.spec.ts
@@ -20,7 +20,7 @@ describe("AxelarDepositRecoveryAPI", () => {
     const api = new AxelarGMPRecoveryAPI({ environment: Environment.TESTNET });
     test("It should create a command ID from a tx hash and event index", async () => {
       const txHash = "0x0a83f6bff1697bb1f72ee60713427e802f32571f042abfa7c6278024f440e861";
-      const res = await api.manualRelayToDestChain(txHash, undefined, evmWalletDetails);
+      const res = await api.manualRelayToDestChain(txHash, undefined, undefined, evmWalletDetails);
       expect(res).toBeTruthy();
     }, 120000);
   });

--- a/src/libs/types/index.ts
+++ b/src/libs/types/index.ts
@@ -122,7 +122,7 @@ export interface AddGasOptions {
   refundAddress?: string;
   estimatedGasUsed?: number;
   gasMultipler?: number;
-  eventIndex?: number;
+  logIndex?: number;
   destChain?: string;
   evmWalletDetails?: EvmWalletDetails;
 }


### PR DESCRIPTION
1. adding `eventIndex` as an optional parameter to `manualRelayToDestinationChain`
2. using ankr as filecoin testnet rpc