### PR TITLE
chore: adjust params

### DIFF
--- a/src/libs/AxelarQueryAPI.ts
+++ b/src/libs/AxelarQueryAPI.ts
@@ -312,10 +312,12 @@ export class AxelarQueryAPI {
       ? srcGasFeeWei
       : srcGasFeeWei.mul(minDestGasFeeWei).div(destGasFeeWei);
 
-    const _gasMultiplier = gasMultiplier === "auto" ? executeGasMultiplier : gasMultiplier;
+    const actualGasMultiplier = gasMultiplier === "auto" ? executeGasMultiplier : gasMultiplier;
 
     const executionFeeWithMultiplier =
-      _gasMultiplier > 1 ? executionFee.mul(_gasMultiplier * 10000).div(10000) : executionFee;
+      actualGasMultiplier > 1
+        ? executionFee.mul(actualGasMultiplier * 10000).div(10000)
+        : executionFee;
 
     return gmpParams?.showDetailedFees
       ? {
@@ -324,7 +326,7 @@ export class AxelarQueryAPI {
           executionFee: executionFee.toString(),
           executionFeeWithMultiplier: executionFeeWithMultiplier.toString(),
           gasLimit,
-          gasMultiplier: _gasMultiplier,
+          gasMultiplier: actualGasMultiplier,
           minGasPrice: minGasPrice === "0" ? "NA" : minGasPrice,
           apiResponse,
           isExpressSupported: expressSupported,

--- a/src/libs/AxelarQueryAPI.ts
+++ b/src/libs/AxelarQueryAPI.ts
@@ -280,8 +280,8 @@ export class AxelarQueryAPI {
       throw new Error("Failed to estimate gas fee");
     }
 
-    if (BigNumber.from(gasLimit).lt(21000)) {
-      throw new Error("Gas limit is too low");
+    if (!BigNumber.from(gasLimit).gt(0)) {
+      throw new Error("Gas limit must be provided");
     }
 
     const destGasFeeWei = BigNumberUtils.multiplyToGetWei(

--- a/src/libs/AxelarQueryAPI.ts
+++ b/src/libs/AxelarQueryAPI.ts
@@ -6,7 +6,6 @@ import { RestService } from "../services";
 import { AxelarQueryAPIConfig, BaseFeeResponse, Environment } from "./types";
 import { EvmChain } from "../constants/EvmChain";
 import { GasToken } from "../constants/GasToken";
-import { DEFAULT_ESTIMATED_GAS } from "../constants";
 import { AxelarQueryClient, AxelarQueryClientType } from "./AxelarQueryClient";
 import fetch from "cross-fetch";
 import {
@@ -281,8 +280,8 @@ export class AxelarQueryAPI {
       throw new Error("Failed to estimate gas fee");
     }
 
-    if(gasLimit < 21000) {
-      throw new Error("Gas limit is too low.");
+    if (BigNumber.from(gasLimit).lt(21000)) {
+      throw new Error("Gas limit is too low");
     }
 
     const destGasFeeWei = BigNumberUtils.multiplyToGetWei(

--- a/src/libs/AxelarQueryAPI.ts
+++ b/src/libs/AxelarQueryAPI.ts
@@ -256,8 +256,8 @@ export class AxelarQueryAPI {
     sourceChainId: EvmChain | string,
     destinationChainId: EvmChain | string,
     sourceChainTokenSymbol: GasToken | string,
-    gasLimit: BigNumberish = DEFAULT_ESTIMATED_GAS,
-    gasMultiplier = 1.1,
+    gasLimit: BigNumberish,
+    gasMultiplier = 1.0,
     minGasPrice = "0",
     gmpParams?: GMPParams
   ): Promise<string | AxelarQueryAPIFeeResponse> {
@@ -279,6 +279,10 @@ export class AxelarQueryAPI {
 
     if (!success || !baseFee || !sourceToken) {
       throw new Error("Failed to estimate gas fee");
+    }
+
+    if(gasLimit < 21000) {
+      throw new Error("Gas limit is too low.");
     }
 
     const destGasFeeWei = BigNumberUtils.multiplyToGetWei(

--- a/src/libs/types/index.ts
+++ b/src/libs/types/index.ts
@@ -71,6 +71,7 @@ export interface BaseFeeResponse {
   error?: string;
   baseFee: string;
   expressFee: string;
+  executeGasMultiplier: number;
   sourceToken: {
     gas_price: string;
     decimals: number;


### PR DESCRIPTION
Removed default value for `gasLimit`. If specified, it should be greater than the minimum value (21k gas).