### PR TITLE
chore: bump version to 0.14.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,8 +6,8 @@ on:
       - main
 
 jobs:
-  publish-npm:
-    name: "Publish to NPM"
+  build:
+    name: "Build Package"
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ Breaking Changes
 
 **AxelarGMPRecoveryAPI**
 
-- `addNativeGas` & `addGasToCosmosChain`: `gasLimit` is now required, removing the default `700,000`.
+- addNativeGas & addGasToCosmosChain: `gasLimit` is now required, removing the default `700,000`.
 
 ## [0.13.10] - 2024-FEBRUARY-9
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [0.14.0] - 2024-FEBRUARY-9
+
+Breaking Changes
+
+**AxelarQueryAPI**: estimateGasFee
+
+- gasLimit: Changed from optional (default 700,000) to required.
+- gasMultiplier: Default changed from 1.1 to auto, using data from [getFees](https://docs.axelarscan.io/interchain/getFees).
+
+**AxelarGMPRecoveryAPI**
+
+- `addNativeGas` & `addGasToCosmosChain`: `gasLimit` is now required, removing the default `700,000`.
+
 ## [0.13.10] - 2024-FEBRUARY-9
 
 - Remove unused internal APIs

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@axelar-network/axelarjs-sdk",
-  "version": "0.13.10",
+  "version": "0.14.0",
   "description": "The JavaScript SDK for Axelar Network",
   "repository": {
     "type": "git",

--- a/src/libs/AxelarQueryAPI.ts
+++ b/src/libs/AxelarQueryAPI.ts
@@ -248,8 +248,9 @@ export class AxelarQueryAPI {
    * @param sourceChainId Can be of the EvmChain enum or string. If string, should try to generalize to use the CHAINS constants (e.g. CHAINS.MAINNET.ETHEREUM)
    * @param destinationChainId Can be of the EvmChain enum or string. If string, should try to generalize to use the CHAINS constants (e.g. CHAINS.MAINNET.ETHEREUM)
    * @param sourceChainTokenSymbol
-   * @param gasLimit (Optional) An estimated gas amount required to execute `executeWithToken` function. The default value is 700000 which should be sufficient for most transactions.
+   * @param gasLimit An estimated gas amount required to execute `executeWithToken` function.
    * @param gasMultiplier (Optional) A multiplier used to create a buffer above the calculated gas fee, to account for potential slippage throughout tx execution, e.g. 1.1 = 10% buffer. supports up to 3 decimal places
+   * The default value is "auto", which uses the gas multiplier from the fee response
    * @param minGasPrice (Optional) A minimum value, in wei, for the gas price on the destination chain that is used to override the estimated gas price if it falls below this specified value.
    * @param gmpParams (Optional) Additional parameters for GMP transactions, including the ability to see a detailed view of the fee response
    * @returns

--- a/src/libs/TransactionRecoveryApi/AxelarGMPRecoveryAPI.ts
+++ b/src/libs/TransactionRecoveryApi/AxelarGMPRecoveryAPI.ts
@@ -921,6 +921,7 @@ export class AxelarGMPRecoveryAPI extends AxelarRecoveryApi {
    * If the transaction details is not valid, it will return an error with reason.
    * @param chain - source chain
    * @param txHash - transaction hash
+   * @param estimatedGasUsed - estimated gas used
    * @param options - options
    * @returns
    */


### PR DESCRIPTION
[0.14.0] - 2024-FEBRUARY-9
Breaking Changes

AxelarQueryAPI: estimateGasFee

gasLimit: Changed from optional (default 700,000) to required.
gasMultiplier: Default changed from 1.1 to auto, using data from [getFees](https://docs.axelarscan.io/interchain/getFees).
AxelarGMPRecoveryAPI

addNativeGas & addGasToCosmosChain: gasLimit is now required, removing the default 700,000.