### PR TITLE
chore: ensure 2 decimal places

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [0.14.1] - 2024-FEBRUARY-16
+
+- Fix floating points issue for `executeGasMultiplier` in `estimateGasFee` function.
+
 ## [0.14.0] - 2024-FEBRUARY-9
 
 Breaking Changes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@axelar-network/axelarjs-sdk",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "description": "The JavaScript SDK for Axelar Network",
   "repository": {
     "type": "git",

--- a/src/libs/AxelarQueryAPI.ts
+++ b/src/libs/AxelarQueryAPI.ts
@@ -218,8 +218,8 @@ export class AxelarQueryAPI {
         destination_native_token,
         express_fee_string,
         express_supported,
-        execute_gas_multiplier,
       } = response.result;
+      const execute_gas_multiplier = response.result.execute_gas_multiplier as number;
       const { decimals: sourceTokenDecimals } = source_token;
       const baseFee = parseUnits(source_base_fee_string, sourceTokenDecimals).toString();
       const expressFee = express_fee_string
@@ -230,7 +230,7 @@ export class AxelarQueryAPI {
         baseFee,
         expressFee,
         sourceToken: source_token,
-        executeGasMultiplier: execute_gas_multiplier,
+        executeGasMultiplier: parseFloat(execute_gas_multiplier.toFixed(2)),
         destToken: {
           gas_price: destination_native_token.gas_price,
           gas_price_gwei: parseInt(destination_native_token.gas_price_gwei).toString(),


### PR DESCRIPTION
# Description

[AXE-3183](https://axelarnetwork.atlassian.net/browse/AXE-3183)

This PR ensures that the `gas_execute_multiplier` which returns from the `getFees` API has 2 decimal places at maximum before put into the calculation.

## Example

Try calling `estimateGasFee` function given axelar and optimism are source chain and destination chain respectively.

### Before

```
Execute Gas Multiplier 1.1550000000000002
Execute Gas Multiplier 1.32
axelarnet to optimism fee: 0.00000000000412665 ETH
optimism to axelarnet fee: 0.01002625182289159 ETH
```

### After

```
Execute Gas Multiplier 1.16
Execute Gas Multiplier 1.32
axelarnet to optimism fee: 0.000000000004133053 ETH
optimism to axelarnet fee: 0.010016512870193104 ETH
```

[AXE-3183]: https://axelarnetwork.atlassian.net/browse/AXE-3183?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ