### PR TITLE
feat: support cosmos-to-cosmos gmp tx recovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Improved the accuracy of `estimateGasFee` function by incorporating L1 rollup fee for destination L2 chain.
 - Fix for `manualRelayToDestinationChain` to respect optional `provider` parameter
+- Add support for recovery of cosmos-to-cosmos GMP calls
 
 Breaking Changes:
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@axelar-network/axelarjs-sdk",
-  "version": "0.14.3-alpha.1",
+  "version": "0.15.0-alpha.1",
   "description": "The JavaScript SDK for Axelar Network",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@axelar-network/axelarjs-sdk",
-  "version": "0.14.2",
+  "version": "0.14.3-alpha.1",
   "description": "The JavaScript SDK for Axelar Network",
   "repository": {
     "type": "git",


### PR DESCRIPTION
# Description

[AXE-3351](https://axelarnetwork.atlassian.net/browse/AXE-3351?atlOrigin=eyJpIjoiNjIxZjQ1NTlkMTJlNDIyMDg0NmU1MzQxMzUzNmFiMDYiLCJwIjoiaiJ9)

Added support for cosmos-to-cosmos gmp tx recovery

Example Tx: https://axelarscan.io/gmp/292DF0120C85D85CB90270159FD7CB3C552DA2B076F56577AC5608EA226AF26D

[AXE-3351]: https://axelarnetwork.atlassian.net/browse/AXE-3351?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ