### PR TITLE
fix: custom rpc provider is not used for tx recovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## [0.15.0] - 2024-FEBRUARY-21
+## [0.15.0] - 2024-MARCH-X
 
 - Improved the accuracy of `estimateGasFee` function by incorporating L1 rollup fee for destination L2 chain.
+- Fix for `manualRelayToDestinationChain` to respect optional `provider` parameter
 
 Breaking Changes:
 

--- a/src/libs/TransactionRecoveryApi/AxelarGMPRecoveryAPI.ts
+++ b/src/libs/TransactionRecoveryApi/AxelarGMPRecoveryAPI.ts
@@ -218,7 +218,8 @@ export class AxelarGMPRecoveryAPI extends AxelarRecoveryApi {
     srcChainId: string,
     destChainId: string,
     srcTxHash: string,
-    srcTxEventIndex: number | undefined
+    srcTxEventIndex: number | undefined,
+    evmWalletDetails?: EvmWalletDetails
   ): Promise<{
     commandId: string;
     eventResponse: EventResponse;
@@ -228,7 +229,7 @@ export class AxelarGMPRecoveryAPI extends AxelarRecoveryApi {
   }> {
     const eventIndex =
       srcTxEventIndex ??
-      (await this.getEventIndex(srcChainId, srcTxHash)
+      (await this.getEventIndex(srcChainId, srcTxHash, evmWalletDetails)
         .then((index) => index as number)
         .catch(() => -1));
 
@@ -321,7 +322,13 @@ export class AxelarGMPRecoveryAPI extends AxelarRecoveryApi {
         };
       }
 
-      const updatedEvent = await this.getEvmEvent(srcChain, destChain, txHash, txEventIndex);
+      const updatedEvent = await this.getEvmEvent(
+        srcChain,
+        destChain,
+        txHash,
+        txEventIndex,
+        evmWalletDetails
+      );
 
       if (this.isEVMEventCompleted(updatedEvent?.eventResponse)) {
         return {
@@ -801,8 +808,8 @@ export class AxelarGMPRecoveryAPI extends AxelarRecoveryApi {
     );
   }
 
-  public async getEventIndex(chain: string, txHash: string) {
-    const signer = this.getSigner(chain, { useWindowEthereum: false });
+  public async getEventIndex(chain: string, txHash: string, evmWalletDetails?: EvmWalletDetails) {
+    const signer = this.getSigner(chain, evmWalletDetails || { useWindowEthereum: false });
     const receipt = await signer.provider.getTransactionReceipt(txHash).catch(() => undefined);
 
     if (!receipt) {

--- a/src/libs/TransactionRecoveryApi/AxelarGMPRecoveryAPI.ts
+++ b/src/libs/TransactionRecoveryApi/AxelarGMPRecoveryAPI.ts
@@ -466,7 +466,7 @@ export class AxelarGMPRecoveryAPI extends AxelarRecoveryApi {
     if (routeDir === RouteDir.COSMOS_TO_EVM) {
       return this.recoverCosmosToEvmTx(txHash, _evmWalletDetails, messageId);
     } else if (routeDir === RouteDir.EVM_TO_COSMOS) {
-      return this.recoverEvmToCosmosTx(srcChain, txHash, eventIndex);
+      return this.recoverEvmToCosmosTx(srcChain, txHash, eventIndex, _evmWalletDetails);
     } else {
       return this.recoverEvmToEvmTx(
         srcChain,
@@ -492,10 +492,15 @@ export class AxelarGMPRecoveryAPI extends AxelarRecoveryApi {
   private async recoverEvmToCosmosTx(
     srcChain: string,
     txHash: string,
-    txEventIndex?: number | null
+    txEventIndex?: number | null,
+    evmWalletDetails?: EvmWalletDetails
   ) {
     // Check if the tx is confirmed on the source chain
-    const isConfirmed = await this.doesTxMeetConfirmHt(srcChain, txHash);
+    const isConfirmed = await this.doesTxMeetConfirmHt(
+      srcChain,
+      txHash,
+      evmWalletDetails?.provider
+    );
     if (!isConfirmed) {
       const minConfirmLevel = await this.axelarQueryApi.getConfirmationHeight(srcChain);
       return {

--- a/src/libs/TransactionRecoveryApi/client/EVMClient/index.ts
+++ b/src/libs/TransactionRecoveryApi/client/EVMClient/index.ts
@@ -15,7 +15,7 @@ export default class EVMClient {
       this.provider =
         useWindowEthereum && typeof window !== "undefined" && window?.ethereum
           ? new ethers.providers.Web3Provider(window.ethereum, networkOptions)
-          : new ethers.providers.JsonRpcProvider(rpcUrl, networkOptions);
+          : provider || new ethers.providers.JsonRpcProvider(rpcUrl, networkOptions);
     }
     this.signer = privateKey
       ? new ethers.Wallet(privateKey).connect(this.provider)

--- a/src/libs/TransactionRecoveryApi/constants/chain/testnet.ts
+++ b/src/libs/TransactionRecoveryApi/constants/chain/testnet.ts
@@ -6,7 +6,7 @@ export const rpcMap: Record<EvmChain | string, string> = {
   [EvmChain.POLYGON]: "https://rpc-mumbai.maticvigil.com",
   [EvmChain.MOONBEAM]: "https://rpc.api.moonbase.moonbeam.network",
   [EvmChain.AVALANCHE]: "https://api.avax-test.network/ext/bc/C/rpc",
-  "ethereum-2": "https://eth-goerli.api.onfinality.io/public",
+  "ethereum-2": "https://ethereum-goerli-rpc.publicnode.com",
   [EvmChain.AURORA]: "https://testnet.aurora.dev",
   [EvmChain.BINANCE]: "https://data-seed-prebsc-1-s1.binance.org:8545",
   [EvmChain.BNBCHAIN]: "https://data-seed-prebsc-1-s1.binance.org:8545",

--- a/src/libs/test/TransactionRecoveryAPI/AxelarGMPRecoveryAPI.spec.ts
+++ b/src/libs/test/TransactionRecoveryAPI/AxelarGMPRecoveryAPI.spec.ts
@@ -98,7 +98,7 @@ describe("AxelarGMPRecoveryAPI", () => {
         undefined
       );
       expect(mockConfirmGatewayTx).toHaveBeenCalledWith(txHash, EvmChain.AVALANCHE);
-      expect(mockDoesTxMeetConfirmHt).toHaveBeenCalledWith(EvmChain.AVALANCHE, txHash);
+      expect(mockDoesTxMeetConfirmHt).toHaveBeenCalledWith(EvmChain.AVALANCHE, txHash, undefined);
       expect(response).toBeDefined();
       expect(response.infoLogs.length).toBeGreaterThan(0);
       expect(response.eventResponse).toBeDefined();
@@ -165,7 +165,7 @@ describe("AxelarGMPRecoveryAPI", () => {
       );
 
       expect(mockConfirmGatewayTx).toBeCalledTimes(0);
-      expect(mockDoesTxMeetConfirmHt).toHaveBeenCalledWith(EvmChain.AVALANCHE, txHash);
+      expect(mockDoesTxMeetConfirmHt).toHaveBeenCalledWith(EvmChain.AVALANCHE, txHash, undefined);
       expect(response.success).toBeFalsy();
       expect(response.eventResponse).toBeDefined();
       expect(response.commandId).toBe("commandId");
@@ -198,7 +198,7 @@ describe("AxelarGMPRecoveryAPI", () => {
       );
 
       expect(mockConfirmGatewayTx).toHaveBeenCalledWith(txHash, EvmChain.AVALANCHE);
-      expect(mockDoesTxMeetConfirmHt).toHaveBeenCalledWith(EvmChain.AVALANCHE, txHash);
+      expect(mockDoesTxMeetConfirmHt).toHaveBeenCalledWith(EvmChain.AVALANCHE, txHash, undefined);
       expect(response.success).toBeFalsy();
       expect(response.eventResponse).toBeDefined();
       expect(response.commandId).toBe("commandId");


### PR DESCRIPTION
# Description

[AXE-3352](https://axelarnetwork.atlassian.net/browse/AXE-3352?atlOrigin=eyJpIjoiMWU0OGNiN2EzYzUwNDUwYTgxYjJmZGMwZTI2MjE2MWMiLCJwIjoiaiJ9)

This PR updates the `ethereum-2` RPC endpoint and ensures the custom provider is used within `manualRelayToDestChain`

## Example Usage

```ts
// Override default rpc endpoint
await api.manualRelayToDestChain(
    txHash,
    undefined,
    undefined,
    {
      provider: new ethers.providers.JsonRpcProvider(
        "https://goerli.gateway.tenderly.co"
      ),
    }
);
```

[AXE-3352]: https://axelarnetwork.atlassian.net/browse/AXE-3352?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ