### PR TITLE
chore: return 0 for mantle L1 fee

### DIFF
--- a/src/libs/fee/getL1Fee.ts
+++ b/src/libs/fee/getL1Fee.ts
@@ -4,20 +4,7 @@ import { BigNumber, ethers } from "ethers";
 import { EstimateL1FeeParams } from "../types";
 
 const ABI = {
-  Optimism: [
-    // "function getL1GasUsed(bytes executeData) view returns (uint256)",
-    "function getL1Fee(bytes executeData) view returns (uint256)",
-  ],
-  Mantle: [
-    "function overhead() view returns (uint256)",
-    "function scalar() view returns (uint256)",
-  ],
-};
-
-export type ContractCallContext = {
-  reference: string;
-  contractAddress: string;
-  abi: any;
+  Optimism: ["function getL1Fee(bytes executeData) view returns (uint256)"],
 };
 
 /**
@@ -36,17 +23,13 @@ export function getL1FeeForL2(
   const _l1GasOracleAddress = l1GasOracleAddress || "0x420000000000000000000000000000000000000F";
 
   switch (params.l2Type) {
-    case "mantle":
-      return getMantleL1Fee(provider, {
-        ...params,
-        l1GasOracleAddress: _l1GasOracleAddress,
-      });
     case "op":
       return getOptimismL1Fee(provider, {
         ...params,
         l1GasOracleAddress: _l1GasOracleAddress,
       });
-    // Most of the ethereum clients are already included L1 fee in the gas estimation for Arbitrum.
+    // RPC clients for Arbitrum and Mantle include both L1 and L2 components in gasLimit.
+    case "mantle":
     case "arb":
     default:
       return Promise.resolve(BigNumber.from(0));
@@ -59,45 +42,6 @@ async function getOptimismL1Fee(
 ) {
   const { executeData, l1GasOracleAddress } = estimateL1FeeParams;
 
-  const callContext = buildContractCallContext("optimism", l1GasOracleAddress as string);
-
-  const contract = new ethers.Contract(callContext.contractAddress, callContext.abi, provider);
+  const contract = new ethers.Contract(l1GasOracleAddress as string, ABI.Optimism, provider);
   return contract.getL1Fee(executeData);
-}
-
-async function getMantleL1Fee(
-  provider: ethers.providers.Provider,
-  estimateL1FeeParams: EstimateL1FeeParams
-) {
-  const { l1GasPrice, l1GasOracleAddress } = estimateL1FeeParams;
-
-  const callContext = buildContractCallContext("mantle", l1GasOracleAddress as string);
-
-  const contract = new ethers.Contract(callContext.contractAddress, callContext.abi, provider);
-  const fixedOverhead = await contract.overhead();
-
-  return BigNumber.from(l1GasPrice.value).mul(fixedOverhead || 2100);
-}
-
-type L1FeeCalculationType = "optimism" | "mantle";
-
-function buildContractCallContext(
-  type: L1FeeCalculationType,
-  l1GasOracleAddress: string
-): ContractCallContext {
-  if (type === "optimism") {
-    return {
-      reference: "gasOracle",
-      contractAddress: l1GasOracleAddress,
-      abi: ABI.Optimism,
-    };
-  } else if (type === "mantle") {
-    return {
-      reference: "gasOracle",
-      contractAddress: l1GasOracleAddress,
-      abi: ABI.Mantle,
-    };
-  }
-
-  throw new Error("Invalid contract call type");
 }


### PR DESCRIPTION
[AXE-3449](https://axelarnetwork.atlassian.net/browse/AXE-3449) 

According to [Mantle V2 Docs](https://docs-v2.mantle.xyz/devs/concepts/tx-fee/ef#example), we can skip L1 fee calculation for Mantle.

Note: currently, the tests are failed because some functions that generated by `axelarjs-types` are not compatible with live `axelar-core`. We have to update `axelarjs-types` first

[AXE-3449]: https://axelarnetwork.atlassian.net/browse/AXE-3449?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ