### PR TITLE
chore: change executeData type from `0x${string}` to `string`

### DIFF
--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -39,7 +39,7 @@ const devnetConfigs: EnvironmentConfigs = {
 };
 const testnetConfigs: EnvironmentConfigs = {
   resourceUrl: "https://nest-server-testnet.axelar.dev",
-  axelarRpcUrl: "https://rpc-axelar-testnet.imperator.co:443", // "https://testnet.rpc.axelar.dev/chain/axelar",
+  axelarRpcUrl: "https://testnet.rpc.axelar.dev/chain/axelar",
   axelarLcdUrl: "https://lcd-axelar-testnet.imperator.co",
   depositServiceUrl: "https://deposit-service.testnet.axelar.dev",
   axelarGMPApiUrl: "https://testnet.api.gmp.axelarscan.io",

--- a/src/libs/AxelarQueryAPI.ts
+++ b/src/libs/AxelarQueryAPI.ts
@@ -279,7 +279,7 @@ export class AxelarQueryAPI {
   public async calculateL1FeeForDestL2(
     destChainId: EvmChain | string,
     destToken: FeeToken,
-    executeData: `0x${string}` | undefined,
+    executeData: string | undefined,
     sourceToken: FeeToken,
     ethereumToken: BaseFeeResponse["ethereumToken"],
     actualGasMultiplier: number,

--- a/src/libs/AxelarQueryAPI.ts
+++ b/src/libs/AxelarQueryAPI.ts
@@ -343,7 +343,7 @@ export class AxelarQueryAPI {
     gasMultiplier: number | "auto" = "auto",
     sourceChainTokenSymbol?: GasToken | string,
     minGasPrice = "0",
-    executeData?: `0x${string}`,
+    executeData?: string,
     gmpParams?: GMPParams
   ): Promise<string | AxelarQueryAPIFeeResponse> {
     await throwIfInvalidChainIds([sourceChainId, destinationChainId], this.environment);

--- a/src/libs/types/index.ts
+++ b/src/libs/types/index.ts
@@ -245,7 +245,7 @@ export type TokenUnit = {
 };
 
 export type EstimateL1FeeParams = {
-  executeData: `0x${string}`;
+  executeData: string;
   l1GasPrice: TokenUnit;
   destChain: string;
   l1GasOracleAddress?: string | undefined;


### PR DESCRIPTION
# Description

**Problem:** Current param types create compatibility conflicts with popular ecosystem libraries such as ethers.js. This can lead to type error issue.

**Solution:** Refactor param types to use string, aligning with standards used by most ecosystem libraries. This improves compatibility and avoids potential workarounds in the future.

[AXE-3533](https://axelarnetwork.atlassian.net/browse/AXE-3533?atlOrigin=eyJpIjoiNzU2MjI3ZjAyY2E1NDVmODg3N2E1ZjZjZjM3ZmJkOTEiLCJwIjoiaiJ9)

[AXE-3533]: https://axelarnetwork.atlassian.net/browse/AXE-3533?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ