### PR TITLE
Bump axelar-cgp-solidity to 6.2.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   "author": "Axelar Network",
   "license": "MIT",
   "dependencies": {
-    "@axelar-network/axelar-cgp-solidity": "^4.5.0",
+    "@axelar-network/axelar-cgp-solidity": "^6.2.1",
     "@axelar-network/axelarjs-types": "^0.33.0",
     "@cosmjs/json-rpc": "^0.30.1",
     "@cosmjs/stargate": "0.31.0-alpha.1",


### PR DESCRIPTION
https://github.com/axelarnetwork/axelarjs-sdk/issues/302

axelarjs-sdk is depends on @axelar-network/axelar-cgp-solidity@4.5.0 which requires node 16 or 18. Could we update axelar-cgp-solidity to latest version that allows node 20?