### PR TITLE
chore: fix wrong denom when adding gas for cosmos source chain

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@axelar-network/axelarjs-sdk",
-  "version": "0.16.3",
+  "version": "0.16.3-alpha.1",
   "description": "The JavaScript SDK for Axelar Network",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@axelar-network/axelarjs-sdk",
-  "version": "0.16.2",
+  "version": "0.16.3",
   "description": "The JavaScript SDK for Axelar Network",
   "repository": {
     "type": "git",

--- a/src/libs/TransactionRecoveryApi/AxelarGMPRecoveryAPI.ts
+++ b/src/libs/TransactionRecoveryApi/AxelarGMPRecoveryAPI.ts
@@ -889,17 +889,15 @@ export class AxelarGMPRecoveryAPI extends AxelarRecoveryApi {
       };
     }
 
-    const denomOnSrcChain = getIBCDenomOnSrcChain(
-      tx.gas_paid?.returnValues?.denom,
-      chainConfig,
-      chainConfigs
-    );
+    const denom = tx.gas_paid?.returnValues?.asset;
+
+    const denomOnSrcChain = getIBCDenomOnSrcChain(denom, chainConfig, chainConfigs);
 
     if (!matchesOriginalTokenPayment(params.token, denomOnSrcChain)) {
       return {
         success: false,
         info: `The token you are trying to send does not match the token originally \
-          used for gas payment. Please send ${tx.gas_paid?.returnValues?.denom} instead`,
+          used for gas payment. Please send ${denom} instead`,
       };
     }
 
@@ -913,7 +911,7 @@ export class AxelarGMPRecoveryAPI extends AxelarRecoveryApi {
               tx.call.returnValues.destinationChain,
               gasLimit,
               autocalculateGasOptions?.gasMultipler,
-              tx.gas_paid?.returnValues?.denom ?? "uaxl"
+              denom ?? "uaxl"
             ),
           };
 


### PR DESCRIPTION
# Description

https://axelarnetwork.atlassian.net/browse/AXE-6051

Fixed the error when trying to add gas for cosmos source chain from the axelarscan ui. 

## Issue
The sdk expects the `denom` (`usomm`) from the `searchGMP` api in the `gas_paid.returnValues.denom` property, but the api returns ibc asset format instead (`ibc/12A9901F2B585B3563C2AD4919D20ED478CCAB3D7F9ACBB76E829583B99B1DAA`). 

## Solution
@nrsirapop helps adding a new property called `asset` in the api response, so this pr points to that field instead. 