### PR TITLE
chore: update devnet GMP API URL

### DIFF
--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -29,7 +29,7 @@ const devnetConfigs: EnvironmentConfigs = {
   resourceUrl: "https://nest-server-devnet.axelar.dev",
   axelarRpcUrl: "",
   axelarLcdUrl: "",
-  axelarGMPApiUrl: "https://devnet.api.gmp.axelarscan.io",
+  axelarGMPApiUrl: "https://devnet-amplifier.api.axelarscan.io/gmp/",
   axelarscanBaseApiUrl: "",
   depositServiceUrl: "https://deposit-service-devnet-release.devnet.axelar.dev",
   recoveryApiUrl: "",


### PR DESCRIPTION
https://devnet.api.gmp.axelarscan.io/ is returning an error. Not sure if the URL is meant to stay as it is, or needs to change to https://devnet-amplifier.api.axelarscan.io/gmp/, which is the URL that works. 

This is getting in the way of my work, so I had to file a PR. If https://devnet.api.gmp.axelarscan.io/ is meant to be working, could you please recover it asap! and you can close this PR in that case. Thank you.

<img width="1319" alt="image" src="https://github.com/user-attachments/assets/3d205f36-7f68-40df-986e-13cb4f5f27b8" />
