### PR TITLE
fix: update devnet-amplifier GMP URL

### DIFF
--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -41,7 +41,7 @@ const devnetAmplifierConfigs: EnvironmentConfigs = {
   resourceUrl: "https://nest-server-testnet.axelar.dev",
   axelarRpcUrl: "",
   axelarLcdUrl: "",
-  axelarGMPApiUrl: "https://devnet-amplifier.api.gmp.axelarscan.io",
+  axelarGMPApiUrl: "https://devnet-amplifier.api.axelarscan.io/gmp",
   axelarscanBaseApiUrl: "https://devnet-amplifier.api.axelarscan.io",
   depositServiceUrl: "",
   recoveryApiUrl: "",


### PR DESCRIPTION
Although the URL for the `devnet` was updated recently, the `devnet-amplifier` one was not.