### PR TITLE
feat: add estimateITSFee method to AxelarQueryAPI

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@axelar-network/axelarjs-sdk",
-  "version": "0.17.4",
+  "version": "0.17.4-alpha.1",
   "description": "The JavaScript SDK for Axelar Network",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@axelar-network/axelarjs-sdk",
-  "version": "0.17.4-alpha.1",
+  "version": "0.17.4-alpha.2",
   "description": "The JavaScript SDK for Axelar Network",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@axelar-network/axelarjs-sdk",
-  "version": "0.17.3-alpha.4",
+  "version": "0.17.4-alpha.1",
   "description": "The JavaScript SDK for Axelar Network",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@axelar-network/axelarjs-sdk",
-  "version": "0.17.4-alpha.1",
+  "version": "0.17.4",
   "description": "The JavaScript SDK for Axelar Network",
   "repository": {
     "type": "git",

--- a/src/libs/AxelarQueryAPI.ts
+++ b/src/libs/AxelarQueryAPI.ts
@@ -174,6 +174,13 @@ export interface DetailedFeeResponse {
   details?: HopFeeDetails[];
 }
 
+export interface ITSDetailedFeeResponse {
+  totalFee: string;
+  baseFee: string;
+  executionFee: string;
+  executionFeeWithMultiplier: string;
+}
+
 interface EstimateMultihopFeeOptions {
   showDetailedFees?: boolean;
 }
@@ -609,7 +616,7 @@ export class AxelarQueryAPI {
    * @param options - Options for the ITS transaction
    * @returns Promise<string> - The estimated gas fee for the ITS transaction
    */
-  public async estimateITSFee(params: ItsFeeParams) {
+  public async estimateITSFee(params: ItsFeeParams): Promise<string | ITSDetailedFeeResponse> {
     // validate the source and destination chains
     await throwIfInvalidItsChainIds(
       [params.sourceChain, params.destinationChain],

--- a/src/libs/AxelarQueryAPI.ts
+++ b/src/libs/AxelarQueryAPI.ts
@@ -579,7 +579,7 @@ export class AxelarQueryAPI {
       // estimate the gas fee for two hops for amplifier route
       return this.estimateMultihopFee(
         [
-          // first hop is to axelar, the gas limit is calculated by the axelarscan's api, so we set it to 1.
+          // first hop is to axelar, the gas limit is overrided by the axelarscan's api, so we set it to 1.
           {
             sourceChain: params.sourceChain,
             sourceTokenSymbol: params.sourceTokenSymbol,

--- a/src/libs/AxelarQueryAPI.ts
+++ b/src/libs/AxelarQueryAPI.ts
@@ -114,12 +114,14 @@ type HopParams = {
  * Parameters for estimating the fee for an ITS transfer
  */
 type ItsFeeParams = {
+  /** Required parameters **/
   /** The source chain for the ITS transaction */
   sourceChain: string;
 
   /** The destination chain for the ITS transaction */
   destinationChain: string;
 
+  /** Optional parameters **/
   /**
    * The multiplier of gas to be used on execution
    * @default 'auto' (multiplier used by relayer)

--- a/src/libs/AxelarQueryAPI.ts
+++ b/src/libs/AxelarQueryAPI.ts
@@ -19,7 +19,7 @@ import {
   FeeInfoResponse,
   TransferFeeResponse,
 } from "@axelar-network/axelarjs-types/axelar/nexus/v1beta1/query";
-import { throwIfInvalidChainIds, throwIfInvalidItsChainIds } from "../utils";
+import { throwIfInvalidChainIds } from "../utils";
 import { loadChains } from "../chains";
 import s3 from "./TransactionRecoveryApi/constants/s3";
 import { BigNumber, BigNumberish, ethers } from "ethers";

--- a/src/libs/AxelarQueryAPI.ts
+++ b/src/libs/AxelarQueryAPI.ts
@@ -618,14 +618,9 @@ export class AxelarQueryAPI {
    */
   public async estimateITSFee(params: ItsFeeParams): Promise<string | ITSDetailedFeeResponse> {
     // validate the source and destination chains
-    await throwIfInvalidItsChainIds(
-      [params.sourceChain, params.destinationChain],
-      this.environment
-    );
+    await throwIfInvalidChainIds([params.sourceChain, params.destinationChain], this.environment);
 
-    return this.axelarscanApi.post("/gmp/estimateITSFee", {
-      params,
-    });
+    return this.axelarscanApi.post("/gmp/estimateITSFee", params);
   }
 
   /**

--- a/src/libs/AxelarQueryAPI.ts
+++ b/src/libs/AxelarQueryAPI.ts
@@ -19,7 +19,7 @@ import {
   FeeInfoResponse,
   TransferFeeResponse,
 } from "@axelar-network/axelarjs-types/axelar/nexus/v1beta1/query";
-import { throwIfInvalidChainIds } from "../utils";
+import { throwIfInvalidChainIds, throwIfInvalidItsChainIds } from "../utils";
 import { loadChains } from "../chains";
 import s3 from "./TransactionRecoveryApi/constants/s3";
 import { BigNumber, BigNumberish, ethers } from "ethers";
@@ -56,20 +56,12 @@ export interface AxelarQueryAPIFeeResponse {
   isExpressSupported: boolean;
 }
 
-type BaseFeeParams = {
+type HopParams = {
   /** The destination chain for the GMP transaction */
   destinationChain: string;
 
   /** The source chain for the GMP transaction */
   sourceChain: string;
-
-  /**
-   * The gasLimit needed for execution on the destination chain.
-   * For OP Stack chains (Optimism, Base, Scroll, Fraxtal, Blast, Mantle, etc.),
-   * only specify the gasLimit for L2 (L2GasLimit).
-   * The endpoint estimates and bundles the gas needed for L1 (L1GasLimit) automatically.
-   */
-  gasLimit: string;
 
   /**
    * The multiplier of gas to be used on execution
@@ -94,9 +86,15 @@ type BaseFeeParams = {
 
   /** The payload that will be used on destination */
   executeData?: string;
-};
 
-type HopParams = BaseFeeParams & {
+  /**
+   * The gasLimit needed for execution on the destination chain.
+   * For OP Stack chains (Optimism, Base, Scroll, Fraxtal, Blast, Mantle, etc.),
+   * only specify the gasLimit for L2 (L2GasLimit).
+   * The endpoint estimates and bundles the gas needed for L1 (L1GasLimit) automatically.
+   */
+  gasLimit: string;
+
   /** Source address for checking if express is supported */
   sourceContractAddress?: string;
 
@@ -115,7 +113,51 @@ type HopParams = BaseFeeParams & {
 /**
  * Parameters for estimating the fee for an ITS transfer
  */
-type ItsFeeParams = BaseFeeParams;
+type ItsFeeParams = {
+  /** The destination chain for the GMP transaction */
+  destinationChain: string;
+
+  /** The source chain for the GMP transaction */
+  sourceChain: string;
+
+  /**
+   * The multiplier of gas to be used on execution
+   * @default 'auto' (multiplier used by relayer)
+   */
+  gasMultiplier?: number | "auto";
+
+  /**
+   * Minimum destination gas price
+   * @default minimum gas price used by relayer
+   */
+  minGasPrice?: string;
+
+  /** The token symbol on the source chain */
+  sourceTokenSymbol?: string;
+
+  /**
+   * The token address on the source chain
+   * @default "ZeroAddress" for native token
+   */
+  sourceTokenAddress?: string;
+
+  /** The payload that will be used on destination */
+  executeData?: string;
+
+  /**
+   * The gasLimit needed for execution on the destination chain.
+   * For OP Stack chains (Optimism, Base, Scroll, Fraxtal, Blast, Mantle, etc.),
+   * only specify the gasLimit for L2 (L2GasLimit).
+   * The endpoint estimates and bundles the gas needed for L1 (L1GasLimit) automatically.
+   */
+  gasLimit?: string;
+
+  /** amount for checking if express is supported */
+  amount?: string;
+
+  /** token id for checking if express is supported */
+  tokenId?: string;
+};
 
 /**
  * Represents detailed fee information for a single hop

--- a/src/libs/AxelarQueryAPI.ts
+++ b/src/libs/AxelarQueryAPI.ts
@@ -573,7 +573,7 @@ export class AxelarQueryAPI {
     await throwIfInvalidChainIds([params.sourceChain, params.destinationChain], this.environment);
 
     // TODO: Set this flag dynamically based on the source chain and destination chain
-    const isAmplifierRoute = params.sourceChain.includes("ethereum");
+    const isAmplifierRoute = true;
 
     if (isAmplifierRoute) {
       // estimate the gas fee for two hops for amplifier route

--- a/src/libs/AxelarQueryAPI.ts
+++ b/src/libs/AxelarQueryAPI.ts
@@ -568,6 +568,28 @@ export class AxelarQueryAPI {
     }
   }
 
+  /** Estimate the gas fee for an ITS transaction where it routes through axelar */
+  public async estimateITSFee(params: HopParams, options?: EstimateMultihopFeeOptions) {
+    await throwIfInvalidChainIds([params.sourceChain, params.destinationChain], this.environment);
+
+    return this.estimateMultihopFee(
+      [
+        // first hop is to axelar, the gas limit is calculated by the axelarscan's api, so we set it to 1.
+        {
+          sourceChain: params.sourceChain,
+          sourceTokenSymbol: params.sourceTokenSymbol,
+          destinationChain: "axelar",
+          gasLimit: "1",
+        },
+        {
+          ...params,
+          sourceChain: "axelar",
+        },
+      ],
+      options
+    );
+  }
+
   /**
    * Get the denom for an asset given its symbol on a chain
    * @param symbol

--- a/src/libs/test/AxelarQueryAPI.spec.ts
+++ b/src/libs/test/AxelarQueryAPI.spec.ts
@@ -343,48 +343,21 @@ describe("AxelarQueryAPI", () => {
   });
 
   describe("estimateITSFee", () => {
-    let mockEstimateMultihopFee: SpyInstance;
+    let mockEstimateITSFee: SpyInstance;
 
     beforeEach(() => {
-      mockEstimateMultihopFee = vitest.spyOn(api, "estimateMultihopFee").mockResolvedValue("1");
+      mockEstimateITSFee = vitest.spyOn(api.axelarscanApi, "post").mockResolvedValue("1");
     });
 
-    test("It should estimate gas by two hops for an amplifier route", async () => {
+    test("It should estimate ITS transaction gas successfully", async () => {
       const params = {
-        sourceChain: "ethereum-sepolia",
-        destinationChain: "sui",
-        gasLimit: "1000000",
+        sourceChain: "xrpl",
+        destinationChain: "xrpl-evm",
       };
 
-      await api.estimateITSFee(params);
-
-      // Expect estimateMultihopFee to be called with two hops for an amplifier route
-      expect(mockEstimateMultihopFee).toHaveBeenCalledWith(
-        [
-          {
-            sourceChain: params.sourceChain,
-            destinationChain: "axelar",
-            gasLimit: "1",
-          },
-          {
-            ...params,
-            sourceChain: "axelar",
-          },
-        ],
-        undefined
-      );
-    });
-
-    test("It should estimate gas by a single hop for a non-amplifier route", async () => {
-      const params = {
-        sourceChain: "optimism-sepolia",
-        destinationChain: "base-sepolia",
-        gasLimit: "1000000",
-      };
-      await api.estimateITSFee(params);
-
-      // Expect estimateMultihopFee to be called with a single hop for a non-amplifier route
-      expect(mockEstimateMultihopFee).toHaveBeenCalledWith([params], undefined);
+      const response = await api.estimateITSFee(params);
+      expect(response).equals("1");
+      expect(mockEstimateITSFee).toHaveBeenCalledWith("/gmp/estimateITSFee", params);
     });
   });
 

--- a/src/libs/test/AxelarQueryAPI.spec.ts
+++ b/src/libs/test/AxelarQueryAPI.spec.ts
@@ -342,7 +342,7 @@ describe("AxelarQueryAPI", () => {
     });
   });
 
-  describe.only("estimateITSFee", () => {
+  describe("estimateITSFee", () => {
     let mockEstimateMultihopFee: SpyInstance;
 
     beforeEach(() => {

--- a/src/libs/test/TransactionRecoveryAPI/AxelarGMPRecoveryAPI.spec.ts
+++ b/src/libs/test/TransactionRecoveryAPI/AxelarGMPRecoveryAPI.spec.ts
@@ -1206,7 +1206,7 @@ describe("AxelarGMPRecoveryAPI", () => {
     });
   });
 
-  describe.only("addGasToSuiChain", () => {
+  describe("addGasToSuiChain", () => {
     // The default rpc url for testnet doesn't work as of 07 November 2024, so we need to use a custom one for testing.
     const api: AxelarGMPRecoveryAPI = new AxelarGMPRecoveryAPI({ environment: Environment.DEVNET });
     const keypair: Secp256k1Keypair = Secp256k1Keypair.deriveKeypair(


### PR DESCRIPTION
# Description

https://axelarnetwork.atlassian.net/browse/AXE-9253

Added `estimateITSFee` function. 

## Blockers
- [x] ~Add chain-specific gas limit configurations (ITS transfer/deployment) for all environments.~ this is handled by the axelarscan api
- [x] Deploy the estimateItsFee endpoint to the axelarscan API.