### PR TITLE
chore: remove check execution

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@axelar-network/axelarjs-sdk",
-  "version": "0.17.5-alpha.2",
+  "version": "0.17.5-alpha.3",
   "description": "The JavaScript SDK for Axelar Network",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@axelar-network/axelarjs-sdk",
-  "version": "0.17.5-alpha.3",
+  "version": "0.17.5-alpha.4",
   "description": "The JavaScript SDK for Axelar Network",
   "repository": {
     "type": "git",

--- a/src/libs/TransactionRecoveryApi/AxelarGMPRecoveryAPI.ts
+++ b/src/libs/TransactionRecoveryApi/AxelarGMPRecoveryAPI.ts
@@ -1184,10 +1184,6 @@ export class AxelarGMPRecoveryAPI extends AxelarRecoveryApi {
 
     if (!destinationChain) return NotGMPTransactionError();
 
-    // Check if the transaction status is already executed or not.
-    const _isExecuted = await this.isExecuted(txHash);
-    if (_isExecuted) return AlreadyExecutedError();
-
     let gasFeeToAdd = options?.amount;
 
     if (!gasFeeToAdd) {


### PR DESCRIPTION
# Description

Removed the transaction status check in the `addNativeGas` function. This addresses an issue with 2-hop transactions where the check incorrectly returns "executed" if the first hop is complete, even if the second hop hasn't been executed yet.