### PR TITLE
chore: add hedera testnet and mainnet

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@axelar-network/axelarjs-sdk",
-  "version": "0.17.7",
+  "version": "0.17.8",
   "description": "The JavaScript SDK for Axelar Network",
   "repository": {
     "type": "git",

--- a/src/chains/supported-chains-list.ts
+++ b/src/chains/supported-chains-list.ts
@@ -50,6 +50,7 @@ export const CHAINS = {
     BASE_SEPOLIA: "base-sepolia",
     LINEA_SEPOLIA: "linea-sepolia",
     MONAD_SEPOLIA: "monad",
+    HEDERA_SEPOLIA: "hedera",
   },
   MAINNET: {
     ACRE: "acre",
@@ -111,5 +112,6 @@ export const CHAINS = {
     TERRA: "terra-2",
     UMEE: "umee",
     XPLA: "xpla",
+    HEDERA: "hedera",
   },
 };

--- a/src/chains/supported-chains-list.ts
+++ b/src/chains/supported-chains-list.ts
@@ -50,7 +50,7 @@ export const CHAINS = {
     BASE_SEPOLIA: "base-sepolia",
     LINEA_SEPOLIA: "linea-sepolia",
     MONAD_SEPOLIA: "monad",
-    HEDERA_SEPOLIA: "hedera",
+    HEDERA: "hedera",
   },
   MAINNET: {
     ACRE: "acre",

--- a/src/constants/EvmChain.ts
+++ b/src/constants/EvmChain.ts
@@ -31,4 +31,6 @@ export enum EvmChain {
   POLYGON_SEPOLIA = "polygon-sepolia",
   LINEA_SEPOLIA = "linea-sepolia",
   MONAD_SEPOLIA = "monad",
+  HEDERA_SEPOLIA = "hedera",
+  HEDERA = "hedera",
 }

--- a/src/constants/EvmChain.ts
+++ b/src/constants/EvmChain.ts
@@ -31,6 +31,5 @@ export enum EvmChain {
   POLYGON_SEPOLIA = "polygon-sepolia",
   LINEA_SEPOLIA = "linea-sepolia",
   MONAD_SEPOLIA = "monad",
-  HEDERA_SEPOLIA = "hedera",
   HEDERA = "hedera",
 }

--- a/src/constants/GasToken.ts
+++ b/src/constants/GasToken.ts
@@ -35,7 +35,6 @@ export enum GasToken {
   BLAST = "ETH",
   LINEA_SEPOLIA = "ETH",
   MONAD_SEPOLIA = "MON",
-  HEDERA_SEPOLIA = "HBAR",
   HEDERA = "HBAR",
 }
 
@@ -68,7 +67,7 @@ export const nativeGasTokenSymbol: Record<string, Record<EvmChain | string, GasT
     [EvmChain.BASE_SEPOLIA]: GasToken.BASE_SEPOLIA,
     [EvmChain.OPTIMISM_SEPOLIA]: GasToken.OPTIMISM_SEPOLIA,
     [EvmChain.MONAD_SEPOLIA]: GasToken.MONAD_SEPOLIA,
-    [EvmChain.HEDERA_SEPOLIA]: GasToken.HEDERA_SEPOLIA,
+    [EvmChain.HEDERA]: GasToken.HEDERA,
   },
   mainnet: {
     [EvmChain.AVALANCHE]: GasToken.AVAX,

--- a/src/constants/GasToken.ts
+++ b/src/constants/GasToken.ts
@@ -35,6 +35,8 @@ export enum GasToken {
   BLAST = "ETH",
   LINEA_SEPOLIA = "ETH",
   MONAD_SEPOLIA = "MON",
+  HEDERA_SEPOLIA = "HBAR",
+  HEDERA = "HBAR",
 }
 
 export const nativeGasTokenSymbol: Record<string, Record<EvmChain | string, GasToken>> = {
@@ -66,6 +68,7 @@ export const nativeGasTokenSymbol: Record<string, Record<EvmChain | string, GasT
     [EvmChain.BASE_SEPOLIA]: GasToken.BASE_SEPOLIA,
     [EvmChain.OPTIMISM_SEPOLIA]: GasToken.OPTIMISM_SEPOLIA,
     [EvmChain.MONAD_SEPOLIA]: GasToken.MONAD_SEPOLIA,
+    [EvmChain.HEDERA_SEPOLIA]: GasToken.HEDERA_SEPOLIA,
   },
   mainnet: {
     [EvmChain.AVALANCHE]: GasToken.AVAX,
@@ -88,6 +91,7 @@ export const nativeGasTokenSymbol: Record<string, Record<EvmChain | string, GasT
     [EvmChain.CENTRIFUGE]: GasToken.CENTRIFUGE,
     [EvmChain.FRAXTAL]: GasToken.FRAXTAL,
     [EvmChain.BLAST]: GasToken.BLAST,
+    [EvmChain.HEDERA]: GasToken.HEDERA,
   },
 };
 

--- a/src/libs/AxelarGateway.ts
+++ b/src/libs/AxelarGateway.ts
@@ -7,10 +7,10 @@ import {
   SendTokenArgs,
 } from "./types";
 
-import erc20Abi from "./abi/erc20Abi.json";
-import { GatewayTx } from "./GatewayTx";
-import { AxelarQueryClient, AxelarQueryClientType } from "./AxelarQueryClient";
 import { EvmChain } from "../constants/EvmChain";
+import erc20Abi from "./abi/erc20Abi.json";
+import { AxelarQueryClient, AxelarQueryClientType } from "./AxelarQueryClient";
+import { GatewayTx } from "./GatewayTx";
 
 export const AXELAR_GATEWAY: Record<Environment, Partial<Record<EvmChain, string>>> = {
   [Environment.MAINNET]: {
@@ -65,7 +65,7 @@ export const AXELAR_GATEWAY: Record<Environment, Partial<Record<EvmChain, string
     [EvmChain.POLYGON_SEPOLIA]: "0xe432150cce91c13a887f7D836923d5597adD8E31",
     [EvmChain.LINEA_SEPOLIA]: "0xe432150cce91c13a887f7D836923d5597adD8E31",
     [EvmChain.MONAD_SEPOLIA]: "0xe432150cce91c13a887f7D836923d5597adD8E31",
-    [EvmChain.HEDERA_SEPOLIA]: "0xe432150cce91c13a887f7D836923d5597adD8E31",
+    [EvmChain.HEDERA]: "0xe432150cce91c13a887f7D836923d5597adD8E31",
   },
   [Environment.DEVNET]: {
     [EvmChain.ETHEREUM]: "0x7358799e0c8250f0B7D1164824F6Dd5bA31C9Cd6",

--- a/src/libs/AxelarGateway.ts
+++ b/src/libs/AxelarGateway.ts
@@ -33,6 +33,7 @@ export const AXELAR_GATEWAY: Record<Environment, Partial<Record<EvmChain, string
     [EvmChain.IMMUTABLE]: "0xe432150cce91c13a887f7D836923d5597adD8E31",
     [EvmChain.FRAXTAL]: "0xe432150cce91c13a887f7D836923d5597adD8E31",
     [EvmChain.BLAST]: "0xe432150cce91c13a887f7D836923d5597adD8E31",
+    [EvmChain.HEDERA]: "0xe432150cce91c13a887f7D836923d5597adD8E31",
   },
   [Environment.TESTNET]: {
     [EvmChain.ETHEREUM]: "0xe432150cce91c13a887f7D836923d5597adD8E31",
@@ -64,6 +65,7 @@ export const AXELAR_GATEWAY: Record<Environment, Partial<Record<EvmChain, string
     [EvmChain.POLYGON_SEPOLIA]: "0xe432150cce91c13a887f7D836923d5597adD8E31",
     [EvmChain.LINEA_SEPOLIA]: "0xe432150cce91c13a887f7D836923d5597adD8E31",
     [EvmChain.MONAD_SEPOLIA]: "0xe432150cce91c13a887f7D836923d5597adD8E31",
+    [EvmChain.HEDERA_SEPOLIA]: "0xe432150cce91c13a887f7D836923d5597adD8E31",
   },
   [Environment.DEVNET]: {
     [EvmChain.ETHEREUM]: "0x7358799e0c8250f0B7D1164824F6Dd5bA31C9Cd6",

--- a/src/libs/TransactionRecoveryApi/constants/chain/mainnet.ts
+++ b/src/libs/TransactionRecoveryApi/constants/chain/mainnet.ts
@@ -23,7 +23,7 @@ export const rpcMap: Partial<Record<EvmChain | string, string>> = {
   [EvmChain.IMMUTABLE]: "https://rpc.immutable.com",
   [EvmChain.FRAXTAL]: "https://rpc.frax.com",
   [EvmChain.BLAST]: "https://rpc.blast.io",
-  [EvmChain.HEDERA_SEPOLIA]: "https://mainnet.hashio.io/api",
+  [EvmChain.HEDERA]: "https://mainnet.hashio.io/api",
 };
 
 export const networkInfo: Partial<Record<EvmChain, Network>> = {

--- a/src/libs/TransactionRecoveryApi/constants/chain/mainnet.ts
+++ b/src/libs/TransactionRecoveryApi/constants/chain/mainnet.ts
@@ -111,4 +111,8 @@ export const networkInfo: Partial<Record<EvmChain, Network>> = {
     chainId: 81457,
     name: EvmChain.BLAST,
   },
+  [EvmChain.HEDERA]: {
+    chainId: 295,
+    name: EvmChain.HEDERA,
+  },
 };

--- a/src/libs/TransactionRecoveryApi/constants/chain/mainnet.ts
+++ b/src/libs/TransactionRecoveryApi/constants/chain/mainnet.ts
@@ -23,6 +23,7 @@ export const rpcMap: Partial<Record<EvmChain | string, string>> = {
   [EvmChain.IMMUTABLE]: "https://rpc.immutable.com",
   [EvmChain.FRAXTAL]: "https://rpc.frax.com",
   [EvmChain.BLAST]: "https://rpc.blast.io",
+  [EvmChain.HEDERA_SEPOLIA]: "https://mainnet.hashio.io/api",
 };
 
 export const networkInfo: Partial<Record<EvmChain, Network>> = {

--- a/src/libs/TransactionRecoveryApi/constants/chain/testnet.ts
+++ b/src/libs/TransactionRecoveryApi/constants/chain/testnet.ts
@@ -1,5 +1,5 @@
-import { EvmChain } from "../../../../constants/EvmChain";
 import { Network } from "@ethersproject/networks";
+import { EvmChain } from "../../../../constants/EvmChain";
 
 export const rpcMap: Record<EvmChain | string, string> = {
   [EvmChain.FANTOM]: "https://rpc.testnet.fantom.network",
@@ -26,7 +26,7 @@ export const rpcMap: Record<EvmChain | string, string> = {
   [EvmChain.POLYGON_SEPOLIA]: "https://rpc-amoy.polygon.technology",
   [EvmChain.LINEA_SEPOLIA]: "https://rpc.sepolia.linea.build",
   [EvmChain.MONAD_SEPOLIA]: "https://testnet-rpc.monad.xyz",
-  [EvmChain.HEDERA_SEPOLIA]: "https://testnet.hashio.io/api",
+  [EvmChain.HEDERA]: "https://testnet.hashio.io/api",
 };
 
 export const networkInfo: Record<EvmChain | string, Network> = {
@@ -126,8 +126,8 @@ export const networkInfo: Record<EvmChain | string, Network> = {
     chainId: 10143,
     name: EvmChain.MONAD_SEPOLIA,
   },
-  [EvmChain.HEDERA_SEPOLIA]: {
+  [EvmChain.HEDERA]: {
     chainId: 296,
-    name: EvmChain.HEDERA_SEPOLIA,
+    name: EvmChain.HEDERA,
   },
 };

--- a/src/libs/TransactionRecoveryApi/constants/chain/testnet.ts
+++ b/src/libs/TransactionRecoveryApi/constants/chain/testnet.ts
@@ -126,4 +126,8 @@ export const networkInfo: Record<EvmChain | string, Network> = {
     chainId: 10143,
     name: EvmChain.MONAD_SEPOLIA,
   },
+  [EvmChain.HEDERA_SEPOLIA]: {
+    chainId: 296,
+    name: EvmChain.HEDERA_SEPOLIA,
+  },
 };

--- a/src/libs/TransactionRecoveryApi/constants/chain/testnet.ts
+++ b/src/libs/TransactionRecoveryApi/constants/chain/testnet.ts
@@ -26,6 +26,7 @@ export const rpcMap: Record<EvmChain | string, string> = {
   [EvmChain.POLYGON_SEPOLIA]: "https://rpc-amoy.polygon.technology",
   [EvmChain.LINEA_SEPOLIA]: "https://rpc.sepolia.linea.build",
   [EvmChain.MONAD_SEPOLIA]: "https://testnet-rpc.monad.xyz",
+  [EvmChain.HEDERA_SEPOLIA]: "https://testnet.hashio.io/api",
 };
 
 export const networkInfo: Record<EvmChain | string, Network> = {


### PR DESCRIPTION
* Add hedera testnet and mainnet
* Bump up version

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds Hedera (mainnet/testnet) across chains, enums, gas tokens, RPC/network config, and gateway addresses; bumps version to 0.17.8.
> 
> - **Chains/Networks**:
>   - Add `HEDERA` to `src/chains/supported-chains-list.ts` for both `TESTNET` and `MAINNET`.
>   - Extend `EvmChain` with `HEDERA`.
> - **Gas Tokens**:
>   - Add `HBAR` to `GasToken` and map to `EvmChain.HEDERA` in `nativeGasTokenSymbol` for `testnet` and `mainnet`.
> - **Gateway**:
>   - Add Hedera addresses to `AXELAR_GATEWAY` for `MAINNET` and `TESTNET` in `AxelarGateway`.
> - **TransactionRecoveryApi**:
>   - Add Hedera RPC endpoints and `networkInfo` (chainIds: mainnet `295`, testnet `296`).
> - **Version**:
>   - Bump package version to `0.17.8`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9235c2b9c7cf28a59eb77e89ccff082ddd864764. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->