### PR TITLE
feat(axelar-query-api): get active chains once

### DIFF
--- a/src/libs/AxelarQueryAPI.ts
+++ b/src/libs/AxelarQueryAPI.ts
@@ -720,7 +720,11 @@ export class AxelarQueryAPI {
    * @param chainIds A list of chainIds to check
    */
   public async throwIfInactiveChains(chainIds: EvmChain[] | string[]) {
-    const results = await Promise.all(chainIds.map((chainId) => this.isChainActive(chainId)));
+    const activeChains = await this.getActiveChains();
+    const activeChainsNormalised = activeChains.map((chain) => chain.toLowerCase());
+    const results = chainIds.map((chainId) =>
+      activeChainsNormalised.includes(chainId.toLowerCase())
+    );
 
     for (let i = 0; i < chainIds.length; i++) {
       if (!results[i]) {

--- a/src/libs/AxelarQueryAPI.ts
+++ b/src/libs/AxelarQueryAPI.ts
@@ -721,9 +721,9 @@ export class AxelarQueryAPI {
    */
   public async throwIfInactiveChains(chainIds: EvmChain[] | string[]) {
     const activeChains = await this.getActiveChains();
-    const activeChainsNormalised = activeChains.map((chain) => chain.toLowerCase());
+    const activeChainsNormalized = activeChains.map((chain) => chain.toLowerCase());
     const results = chainIds.map((chainId) =>
-      activeChainsNormalised.includes(chainId.toLowerCase())
+      activeChainsNormalized.includes(chainId.toLowerCase())
     );
 
     for (let i = 0; i < chainIds.length; i++) {


### PR DESCRIPTION
Noticed the RPC node intermittently fails with 500 when called too frequently by the test suite.
This change reduces unnecessary calls by retrieving active chains from the Axelar RPC node only once for the whole array of passed chains in `throwIfInactiveChains`
Typically, this method is only called with no more than 2 arguments, so not a mind-boggling improvement, but worthy of a PR. This method is covered by a unit test.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Optimize `throwIfInactiveChains` to query active chains once and check membership locally, reducing RPC calls.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2ba338bccaf51ad7e02c327eb5f088e11555eef4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->