### PR TITLE
chore: bump version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@axelar-network/axelarjs-sdk",
-  "version": "0.19.0",
+  "version": "0.19.1",
   "description": "The JavaScript SDK for Axelar Network",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Bumping version for npm publishing purposes

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Version-only change; no runtime logic, dependencies, or API behavior is modified.
> 
> **Overview**
> Updates `package.json` to bump the published SDK version from `0.19.0` to `0.19.1` (no functional code changes).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3af6c40f0c55163fb1ce214650b05f730bd94069. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->