### PR TITLE
feat: adjust mantle fee calculations for arsia upgrade

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@axelar-network/axelarjs-sdk",
-  "version": "0.19.1",
+  "version": "0.20.0",
   "description": "The JavaScript SDK for Axelar Network",
   "repository": {
     "type": "git",

--- a/src/libs/AxelarQueryAPI.ts
+++ b/src/libs/AxelarQueryAPI.ts
@@ -54,6 +54,8 @@ export interface AxelarQueryAPIFeeResponse {
   executionFeeWithMultiplier: string;
   l1ExecutionFeeWithMultiplier: string;
   l1ExecutionFee: string;
+  operatorExecutionFee?: string;
+  operatorExecutionFeeWithMultiplier?: string;
   gasMultiplier: number;
   gasLimit: BigNumberish;
   minGasPrice: string;
@@ -398,6 +400,8 @@ export class AxelarQueryAPI {
           symbol: destination_native_token.symbol,
           l1_gas_oracle_address: destination_native_token.l1_gas_oracle_address,
           l1_gas_price_in_units: destination_native_token.l1_gas_price_in_units,
+          operator_fee_scalar: destination_native_token.operator_fee_scalar,
+          operator_fee_constant: destination_native_token.operator_fee_constant,
         },
         l2_type,
         ethereumToken: ethereum_token as BaseFeeResponse["ethereumToken"],
@@ -422,6 +426,13 @@ export class AxelarQueryAPI {
     return getL1FeeForL2(provider, l1FeeParams);
   }
 
+  /**
+   * Calculate the L1 execution fee for a destination L2, converted to source-token wei.
+   *
+   * @param ethereumToken Deprecated: retained for backward compatibility only. The
+   *   conversion now uses `destToken.token_price.usd` directly, so this parameter
+   *   is no longer read. Will be removed in a future major version.
+   */
   public async calculateL1FeeForDestL2(
     destChainId: EvmChain | string,
     destToken: FeeToken,
@@ -442,7 +453,9 @@ export class AxelarQueryAPI {
         );
       }
 
-      // Calculate the L1 execution fee. This value is in ETH wei.
+      // Calculate the L1 execution fee. The value is denominated in the destination
+      // chain's native token wei (see getL1FeeForL2): ETH wei for ETH-native OP Stack
+      // chains (optimism, base, blast, fraxtal, scroll), MNT wei for Mantle post-Arsia.
       l1ExecutionFee = await this.estimateL1GasFee(destChainId, {
         executeData: executeData || DEFAULT_L1_EXECUTE_DATA,
         l1GasPrice: destToken.l1_gas_price_in_units,
@@ -451,13 +464,19 @@ export class AxelarQueryAPI {
         l2Type,
       });
 
-      // Convert the L1 execution fee to the source token
+      // Convert the L1 execution fee to the source token using the destination
+      // native token's USD price. For ETH-native chains destToken and ethereumToken
+      // carry the same native asset; any basis-point drift between the two USD
+      // prices from gmp-api falls inside the existing Math.ceil(ratio × 1000)/1000
+      // rounding tolerance. For Mantle this uses MNT/USD, which is what we want.
+      // `ethereumToken` is kept in the signature for backward compatibility (external
+      // callers may pass it) but is no longer read here.
       const srcTokenPrice = Number(sourceToken.token_price.usd);
-      const ethTokenPrice = Number(ethereumToken.token_price.usd);
-      const ethToSrcTokenPriceRatio = ethTokenPrice / srcTokenPrice;
+      const destTokenPrice = Number(destToken.token_price.usd);
+      const destToSrcTokenPriceRatio = destTokenPrice / srcTokenPrice;
 
       let actualL1ExecutionFee = l1ExecutionFee
-        .mul(Math.ceil(ethToSrcTokenPriceRatio * 1000))
+        .mul(Math.ceil(destToSrcTokenPriceRatio * 1000))
         .div(1000);
 
       if (sourceToken.decimals !== destToken.decimals) {
@@ -475,6 +494,74 @@ export class AxelarQueryAPI {
     }
 
     return [l1ExecutionFee, l1ExecutionFeeWithMultiplier];
+  }
+
+  /**
+   * Calculate the OP Stack Isthmus operator fee for a destination L2, converted
+   * to source-token wei.
+   *
+   * Intended to be called only when the destination applies the Isthmus formula.
+   * That's signaled by the presence of `operator_fee_scalar` / `operator_fee_constant`
+   * in the gmp-api `getFees` response; the caller is expected to check for those
+   * before invoking this helper.
+   *
+   * Formula (OP Stack Isthmus spec):
+   *   operatorFee = gasUsed × operatorFeeScalar × 100 + operatorFeeConstant  (destination-native wei)
+   *
+   * Defensive: if the destination's scalar and constant are both zero/absent,
+   * returns `[0, 0]` rather than throwing.
+   *
+   * @param destToken Destination-chain native token. Expected to include
+   *   operator_fee_scalar and operator_fee_constant from the gmp-api `getFees` response.
+   * @param sourceToken Source-chain token (used for USD-price conversion).
+   * @param gasLimit L2 gas estimate for the execute step — the same value passed
+   *   to estimateGasFee.
+   * @param actualGasMultiplier Gas multiplier to apply for a padded estimate.
+   * @returns `[operatorFee, operatorFeeWithMultiplier]` in source-token wei.
+   */
+  public async calculateIsthmusOperatorFeeForDestL2(
+    destToken: FeeToken,
+    sourceToken: FeeToken,
+    gasLimit: BigNumberish,
+    actualGasMultiplier: number
+  ): Promise<[BigNumber, BigNumber]> {
+    let operatorFee = BigNumber.from(0);
+    let operatorFeeWithMultiplier = BigNumber.from(0);
+
+    // Coerce falsy-or-missing fields to "0" before BigNumber.from (`||` rather
+    // than `??` because BigNumber.from("") throws and a stray empty string would
+    // otherwise slip past a nullish check). Both-zero short-circuits to [0, 0]
+    // without doing further work.
+    const scalar = BigNumber.from(destToken.operator_fee_scalar || "0");
+    const constant = BigNumber.from(destToken.operator_fee_constant || "0");
+
+    if (!scalar.isZero() || !constant.isZero()) {
+      // operatorFee = gasUsed × scalar × 100 + constant   (destination-native wei)
+      const operatorFeeNativeWei = BigNumber.from(gasLimit).mul(scalar).mul(100).add(constant);
+
+      // Convert to source token using destination native's USD price (same pattern
+      // as calculateL1FeeForDestL2).
+      const srcTokenPrice = Number(sourceToken.token_price.usd);
+      const destTokenPrice = Number(destToken.token_price.usd);
+      const destToSrcTokenPriceRatio = destTokenPrice / srcTokenPrice;
+
+      let actualOperatorFee = operatorFeeNativeWei
+        .mul(Math.ceil(destToSrcTokenPriceRatio * 1000))
+        .div(1000);
+
+      if (sourceToken.decimals !== destToken.decimals) {
+        actualOperatorFee = BigNumberUtils.convertTokenAmount(
+          actualOperatorFee,
+          destToken.decimals,
+          sourceToken.decimals
+        );
+      }
+
+      operatorFee = BigNumber.from(actualOperatorFee.toString());
+      operatorFeeWithMultiplier = operatorFee.mul(actualGasMultiplier * 10000).div(10000);
+    }
+
+    return [operatorFee, operatorFeeWithMultiplier];
   }
 
   /**
@@ -566,6 +653,33 @@ export class AxelarQueryAPI {
       l2_type
     );
 
+    let total = l1ExecutionFeeWithMultiplier.add(executionFeeWithMultiplier).add(baseFee);
+
+    // OP Stack Isthmus operator fee: computed whenever gmp-api signals the destination
+    // chain has activated it, by emitting operator_fee_scalar / operator_fee_constant
+    // in the getFees response. Today that's gated upstream in gmp-api's getGasPrice.js
+    // to Mantle / mantle-sepolia only (see that file for the hardcoded chain list);
+    // other OP Stack chains join this branch once gmp-api's allowlist is widened.
+    // Pre-compute so the total and the detailed response can fold it in without
+    // later mutation.
+    let isthmusOperatorFeeFields:
+      | { operatorExecutionFee: string; operatorExecutionFeeWithMultiplier: string }
+      | undefined;
+    if (destToken.operator_fee_scalar || destToken.operator_fee_constant) {
+      const [operatorFee, operatorFeeWithMultiplier] =
+        await this.calculateIsthmusOperatorFeeForDestL2(
+          destToken,
+          sourceToken,
+          gasLimit,
+          actualGasMultiplier
+        );
+      total = total.add(operatorFeeWithMultiplier);
+      isthmusOperatorFeeFields = {
+        operatorExecutionFee: operatorFee.toString(),
+        operatorExecutionFeeWithMultiplier: operatorFeeWithMultiplier.toString(),
+      };
+    }
+
     return gmpParams?.showDetailedFees
       ? {
           baseFee,
@@ -574,13 +688,14 @@ export class AxelarQueryAPI {
           executionFeeWithMultiplier: executionFeeWithMultiplier.toString(),
           l1ExecutionFeeWithMultiplier: l1ExecutionFeeWithMultiplier.toString(),
           l1ExecutionFee: l1ExecutionFee.toString(),
+          ...isthmusOperatorFeeFields,
           gasLimit,
           gasMultiplier: actualGasMultiplier,
           minGasPrice: minGasPrice === "0" ? "NA" : minGasPrice,
           apiResponse,
           isExpressSupported: expressSupported,
         }
-      : l1ExecutionFeeWithMultiplier.add(executionFeeWithMultiplier).add(baseFee).toString();
+      : total.toString();
   }
 
   /**

--- a/src/libs/fee/getL1Fee.spec.ts
+++ b/src/libs/fee/getL1Fee.spec.ts
@@ -29,7 +29,17 @@ async function getL1Fee(srcChain: string, destChain: string) {
 describe("getL1Fee", () => {
   it("query l1 fee for l2 chains should work", async () => {
     const srcChain = "ethereum";
-    const destChainsThatShouldIncludeL1Fees = ["optimism", "blast", "fraxtal", "base", "scroll"];
+    // Includes Mantle post-Arsia: getL1FeeForL2 now returns getL1Fee(data) × tokenRatio()
+    // in MNT wei, matching the destination's native charge. Zero only for Arbitrum,
+    // whose L1 component is bundled into gasUsed by its RPC estimator.
+    const destChainsThatShouldIncludeL1Fees = [
+      "optimism",
+      "blast",
+      "fraxtal",
+      "base",
+      "scroll",
+      "mantle",
+    ];
 
     const l1FeeQueries = destChainsThatShouldIncludeL1Fees.map((destChain) =>
       getL1Fee(srcChain, destChain)
@@ -40,7 +50,7 @@ describe("getL1Fee", () => {
     expect(fees.length).toBe(destChainsThatShouldIncludeL1Fees.length);
     expect(fees.every((fee) => fee.gt(0))).toBe(true);
 
-    const destChainsThatShouldNotIncludeL1Fees = ["mantle", "arbitrum"];
+    const destChainsThatShouldNotIncludeL1Fees = ["arbitrum"];
 
     const ZeroL1FeeQueries = destChainsThatShouldNotIncludeL1Fees.map((destChain) =>
       getL1Fee(srcChain, destChain)

--- a/src/libs/fee/getL1Fee.ts
+++ b/src/libs/fee/getL1Fee.ts
@@ -5,14 +5,27 @@ import { EstimateL1FeeParams } from "../types";
 
 const ABI = {
   Optimism: ["function getL1Fee(bytes executeData) view returns (uint256)"],
+  Mantle: [
+    "function getL1Fee(bytes executeData) view returns (uint256)",
+    "function tokenRatio() view returns (uint256)",
+  ],
 };
 
 /**
- * Get the estimated L1 fee for a given L2 chain.
- * @param env The environment to use. Either "mainnet" or "testnet".
- * @param chain The destination L2 chain.
- * @param params The parameters to use for the estimation.
- * @returns The estimated L1 fee.
+ * Get the estimated L1 fee for a given L2 chain, denominated in the destination
+ * chain's native token wei.
+ *
+ * - OP Stack chains with ETH as native (optimism, base, blast, fraxtal, scroll):
+ *   returns the oracle's getL1Fee(data) result, which is already in ETH wei.
+ * - Mantle (post-Arsia): returns getL1Fee(data) × tokenRatio(), which converts
+ *   the oracle's ETH-wei posting cost to MNT wei — matching what Mantle actually
+ *   debits from the user's balance at tx inclusion.
+ * - Arbitrum: returns 0. Arbitrum bundles the L1 component into the L2 gasUsed
+ *   reported by eth_estimateGas, so there's no separate L1 fee to return here.
+ *
+ * @param provider JSON-RPC provider for the destination chain.
+ * @param params Estimation parameters, including executeData and l2Type.
+ * @returns The estimated L1 fee in the destination chain's native token wei.
  */
 export function getL1FeeForL2(
   provider: ethers.providers.JsonRpcProvider,
@@ -28,8 +41,11 @@ export function getL1FeeForL2(
         ...params,
         l1GasOracleAddress: _l1GasOracleAddress,
       });
-    // RPC clients for Arbitrum and Mantle include both L1 and L2 components in gasLimit.
     case "mantle":
+      return getMantleL1Fee(provider, {
+        ...params,
+        l1GasOracleAddress: _l1GasOracleAddress,
+      });
     case "arb":
     default:
       return Promise.resolve(BigNumber.from(0));
@@ -44,4 +60,26 @@ async function getOptimismL1Fee(
 
   const contract = new ethers.Contract(l1GasOracleAddress as string, ABI.Optimism, provider);
   return contract.getL1Fee(executeData);
+}
+
+async function getMantleL1Fee(
+  provider: ethers.providers.Provider,
+  estimateL1FeeParams: EstimateL1FeeParams
+): Promise<BigNumber> {
+  const { executeData, l1GasOracleAddress } = estimateL1FeeParams;
+
+  const contract = new ethers.Contract(l1GasOracleAddress as string, ABI.Mantle, provider);
+  const [l1FeeEthWei, tokenRatio] = await Promise.all([
+    contract.getL1Fee(executeData) as Promise<BigNumber>,
+    contract.tokenRatio() as Promise<BigNumber>,
+  ]);
+
+  if (tokenRatio.isZero()) {
+    throw new Error(
+      `Mantle L1 fee oracle at ${l1GasOracleAddress} returned tokenRatio=0; unable to compute L1 fee`
+    );
+  }
+
+  // getL1Fee is ETH wei; tokenRatio is the ETH→MNT conversion factor. Product is MNT wei.
+  return l1FeeEthWei.mul(tokenRatio);
 }

--- a/src/libs/test/AxelarQueryAPI.spec.ts
+++ b/src/libs/test/AxelarQueryAPI.spec.ts
@@ -5,7 +5,7 @@ import {
 import { BigNumber, BigNumberish, ethers } from "ethers";
 import { parseEther, parseUnits } from "ethers/lib/utils";
 import { CHAINS } from "../../chains";
-import { AxelarQueryAPI, DetailedFeeResponse } from "../AxelarQueryAPI";
+import { AxelarQueryAPI, AxelarQueryAPIFeeResponse, DetailedFeeResponse } from "../AxelarQueryAPI";
 import { Environment, FeeToken } from "../types";
 import { EvmChain } from "../../constants/EvmChain";
 import { GasToken } from "../../constants/GasToken";

--- a/src/libs/test/AxelarQueryAPI.spec.ts
+++ b/src/libs/test/AxelarQueryAPI.spec.ts
@@ -6,7 +6,7 @@ import { BigNumber, BigNumberish, ethers } from "ethers";
 import { parseEther, parseUnits } from "ethers/lib/utils";
 import { CHAINS } from "../../chains";
 import { AxelarQueryAPI, DetailedFeeResponse } from "../AxelarQueryAPI";
-import { Environment } from "../types";
+import { Environment, FeeToken } from "../types";
 import { EvmChain } from "../../constants/EvmChain";
 import { GasToken } from "../../constants/GasToken";
 import { activeChainsStub, getFeeStub } from "./stubs";
@@ -116,6 +116,168 @@ describe("AxelarQueryAPI", () => {
         l2Type: "op",
       });
       expect(gasAmount.lt(parseEther("0.005"))).toBeTruthy();
+    });
+  });
+
+  describe("calculateIsthmusOperatorFeeForDestL2", () => {
+    const mantleApi = new AxelarQueryAPI({ environment: Environment.MAINNET });
+
+    // Use matching USD prices so the price-ratio conversion lands on exactly 1.0,
+    // keeping the expected values precise and independent of price-rounding.
+    const destToken: FeeToken = {
+      gas_price: "0.0000001",
+      decimals: 18,
+      name: "Mantle",
+      symbol: "MNT",
+      token_price: { usd: 1 },
+      operator_fee_scalar: "100000000",
+      operator_fee_constant: "0",
+    };
+
+    const sourceToken: FeeToken = {
+      gas_price: "0",
+      decimals: 18,
+      name: "Test",
+      symbol: "TEST",
+      token_price: { usd: 1 },
+    };
+
+    test("computes operator fee via the OP Stack Isthmus formula", async () => {
+      // operatorFeeNativeWei = gasLimit × scalar × 100 + constant
+      //                     = 200000 × 1e8 × 100 + 0
+      //                     = 2e15
+      const [fee] = await mantleApi.calculateIsthmusOperatorFeeForDestL2(
+        destToken,
+        sourceToken,
+        200000,
+        1.0
+      );
+      expect(fee.toString()).toBe("2000000000000000");
+    });
+
+    test("applies gas multiplier", async () => {
+      // 2e15 × 1.1 = 2.2e15
+      const [, feeWithMultiplier] = await mantleApi.calculateIsthmusOperatorFeeForDestL2(
+        destToken,
+        sourceToken,
+        200000,
+        1.1
+      );
+      expect(feeWithMultiplier.toString()).toBe("2200000000000000");
+    });
+
+    test("returns [0, 0] when scalar and constant are both absent", async () => {
+      const nonIsthmus: FeeToken = {
+        gas_price: "0.0000001",
+        decimals: 18,
+        name: "Other",
+        symbol: "X",
+        token_price: { usd: 1 },
+      };
+      const [fee, feeWithMultiplier] = await mantleApi.calculateIsthmusOperatorFeeForDestL2(
+        nonIsthmus,
+        sourceToken,
+        200000,
+        1.0
+      );
+      expect(fee.eq(0)).toBe(true);
+      expect(feeWithMultiplier.eq(0)).toBe(true);
+    });
+
+    test("includes operatorFeeConstant when scalar is 0", async () => {
+      const constantOnly: FeeToken = {
+        ...destToken,
+        operator_fee_scalar: "0",
+        operator_fee_constant: "1000000000000000", // 1e15
+      };
+      const [fee] = await mantleApi.calculateIsthmusOperatorFeeForDestL2(
+        constantOnly,
+        sourceToken,
+        200000,
+        1.0
+      );
+      // 200000 × 0 × 100 + 1e15 = 1e15
+      expect(fee.toString()).toBe("1000000000000000");
+    });
+
+    test("over-estimates at very small dest-to-source USD ratios (documented rounding)", async () => {
+      // Mantle-like dest ($0.5) → expensive source ($3000). Ratio = 0.000166..., which
+      // the Math.ceil(ratio × 1000) / 1000 rounding coerces up to 0.001. Net effect is
+      // an intentional over-quote of ~6× at extreme price gaps. Test documents the
+      // behavior so it can't silently change.
+      const smallDestToken: FeeToken = {
+        gas_price: "0.0000001",
+        decimals: 18,
+        name: "Mantle",
+        symbol: "MNT",
+        token_price: { usd: 0.5 },
+        operator_fee_scalar: "100000000",
+        operator_fee_constant: "0",
+      };
+      const expensiveSourceToken: FeeToken = {
+        gas_price: "0",
+        decimals: 18,
+        name: "Source",
+        symbol: "ETH",
+        token_price: { usd: 3000 },
+      };
+      const [fee] = await mantleApi.calculateIsthmusOperatorFeeForDestL2(
+        smallDestToken,
+        expensiveSourceToken,
+        200000,
+        1.0
+      );
+      // operatorFeeNativeWei = 200000 × 1e8 × 100 + 0 = 2e15
+      // Rounded ratio = Math.ceil(0.000166... × 1000) / 1000 = 1/1000
+      // Final = 2e15 × 1 / 1000 = 2e12
+      expect(fee.toString()).toBe("2000000000000");
+    });
+  });
+
+  describe("estimateGasFee operator fee dispatch", () => {
+    const mainnetApi = new AxelarQueryAPI({ environment: Environment.MAINNET });
+
+    // GMPParams has required fields (destinationContractAddress, sourceContractAddress,
+    // tokenSymbol) but the getNativeGasBaseFee call treats them as optional. Pass empty
+    // strings to satisfy the type without affecting the quote path.
+    const detailed = {
+      showDetailedFees: true,
+      destinationContractAddress: "",
+      sourceContractAddress: "",
+      tokenSymbol: "",
+    };
+
+    test("populates operatorExecutionFee when destination has Isthmus fields (Mantle today)", async () => {
+      const response = (await mainnetApi.estimateGasFee(
+        EvmChain.ETHEREUM,
+        EvmChain.MANTLE,
+        500000,
+        undefined,
+        undefined,
+        undefined,
+        "0x",
+        detailed
+      )) as AxelarQueryAPIFeeResponse;
+
+      expect(response.operatorExecutionFee).toBeDefined();
+      expect(BigNumber.from(response.operatorExecutionFee as string).gt(0)).toBe(true);
+      expect(response.operatorExecutionFeeWithMultiplier).toBeDefined();
+    });
+
+    test("omits operatorExecutionFee on destinations without Isthmus fields (Optimism today)", async () => {
+      const response = (await mainnetApi.estimateGasFee(
+        EvmChain.ETHEREUM,
+        EvmChain.OPTIMISM,
+        500000,
+        undefined,
+        undefined,
+        undefined,
+        "0x",
+        detailed
+      )) as AxelarQueryAPIFeeResponse;
+
+      expect(response.operatorExecutionFee).toBeUndefined();
+      expect(response.operatorExecutionFeeWithMultiplier).toBeUndefined();
     });
   });
 
@@ -422,6 +584,10 @@ describe("AxelarQueryAPI", () => {
 
       mainnetResponses.forEach((response) => {
         expect(response).toBeDefined();
+        // Every destination in mainnetL2Chains is an L2 with a non-zero L1 (and, for
+        // Mantle, operator) fee component. Stricter than toBeDefined to guard against
+        // regressions where the fee collapses to the base/execution components only.
+        expect(BigNumber.from(response as string).gt(0)).toBe(true);
       });
     });
 

--- a/src/libs/types/index.ts
+++ b/src/libs/types/index.ts
@@ -71,6 +71,8 @@ export type FeeToken = {
   name: string;
   l1_gas_oracle_address?: string;
   l1_gas_price_in_units?: TokenUnit;
+  operator_fee_scalar?: string;
+  operator_fee_constant?: string;
   symbol: string;
   token_price: {
     usd: number;


### PR DESCRIPTION
Part of OCSI-180

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core fee-quote math for Mantle and alters returned fee breakdown/total when operator fee fields are present, which could impact downstream pricing and user payments if incorrect.
> 
> **Overview**
> Updates Mantle L2 fee estimation to match post-Arsia behavior: `getL1FeeForL2` now multiplies Mantle’s `getL1Fee` result by the oracle `tokenRatio()` so the returned L1 component is denominated in the destination native token (MNT) rather than ETH, and the L1-to-source conversion in `calculateL1FeeForDestL2` now uses `destToken` USD price (keeping `ethereumToken` only for backward compatibility).
> 
> Adds support for OP Stack Isthmus operator fees by pluming `operator_fee_scalar`/`operator_fee_constant` through `FeeToken`/`getNativeGasBaseFee`, computing an additional operator execution fee, and including it in `estimateGasFee` totals plus the detailed response (`operatorExecutionFee*`). Tests are expanded/adjusted to cover Mantle’s non-zero L1 fee, the new operator fee helper, and conditional inclusion in detailed fee results; package version is bumped to `0.20.0`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a24ddb1a09218bc1b3f0daf0389f58284df5823a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->