### PR TITLE
feat: gmp recovery solana

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
   "author": "Axelar Network",
   "license": "MIT",
   "dependencies": {
+    "@aws-crypto/sha256-js": "^5.2.0",
     "@axelar-network/axelar-cgp-solidity": "^6.3.0",
     "@axelar-network/axelarjs-types": "^1.2.1",
     "@cosmjs/json-rpc": "^0.33.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@axelar-network/axelarjs-sdk",
-  "version": "0.20.0",
+  "version": "0.21.0",
   "description": "The JavaScript SDK for Axelar Network",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
   "author": "Axelar Network",
   "license": "MIT",
   "dependencies": {
-    "@aws-crypto/sha256-js": "^5.2.0",
     "@axelar-network/axelar-cgp-solidity": "^6.3.0",
     "@axelar-network/axelarjs-types": "^1.3.0",
     "@cosmjs/json-rpc": "^0.38.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,9 +11,6 @@ importers:
 
   .:
     dependencies:
-      '@aws-crypto/sha256-js':
-        specifier: ^5.2.0
-        version: 5.2.0
       '@axelar-network/axelar-cgp-solidity':
         specifier: ^6.3.0
         version: 6.4.0
@@ -193,17 +190,6 @@ packages:
     peerDependencies:
       graphql: ^15.5.0 || ^16.0.0 || ^17.0.0
       typescript: ^5.0.0
-
-  '@aws-crypto/sha256-js@5.2.0':
-    resolution: {integrity: sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==}
-    engines: {node: '>=16.0.0'}
-
-  '@aws-crypto/util@5.2.0':
-    resolution: {integrity: sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==}
-
-  '@aws-sdk/types@3.973.8':
-    resolution: {integrity: sha512-gjlAdtHMbtR9X5iIhVUvbVcy55KnznpC6bkDUWW9z915bi0ckdUr5cjf16Kp6xq0bP5HBD2xzgbL9F9Quv5vUw==}
-    engines: {node: '>=20.0.0'}
 
   '@axelar-network/axelar-cgp-solidity@4.5.0':
     resolution: {integrity: sha512-4F4rmHei0cmzeUR7/mW4Bap5rc/KlPV2crD9HA7HTRfl15mVcN6/3z8p+pAm9We6bOrQplNW9KBZ3HJFP3C1Gw==}
@@ -1196,22 +1182,6 @@ packages:
   '@sindresorhus/is@5.6.0':
     resolution: {integrity: sha512-TV7t8GKYaJWsn00tFDqBw8+Uqmr8A0fRU1tvTQhyZzGv0sJCGRQL3JGMI3ucuKo3XIZdUP+Lx7/gh2t3lewy7g==}
     engines: {node: '>=14.16'}
-
-  '@smithy/is-array-buffer@2.2.0':
-    resolution: {integrity: sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==}
-    engines: {node: '>=14.0.0'}
-
-  '@smithy/types@4.14.1':
-    resolution: {integrity: sha512-59b5HtSVrVR/eYNei3BUj3DCPKD/G7EtDDe7OEJE7i7FtQFugYo6MxbotS8mVJkLNVf8gYaAlEBwwtJ9HzhWSg==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/util-buffer-from@2.2.0':
-    resolution: {integrity: sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==}
-    engines: {node: '>=14.0.0'}
-
-  '@smithy/util-utf8@2.3.0':
-    resolution: {integrity: sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==}
-    engines: {node: '>=14.0.0'}
 
   '@socket.io/component-emitter@3.1.2':
     resolution: {integrity: sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA==}
@@ -3678,23 +3648,6 @@ snapshots:
       graphql: 16.12.0
       typescript: 5.9.3
 
-  '@aws-crypto/sha256-js@5.2.0':
-    dependencies:
-      '@aws-crypto/util': 5.2.0
-      '@aws-sdk/types': 3.973.8
-      tslib: 2.8.1
-
-  '@aws-crypto/util@5.2.0':
-    dependencies:
-      '@aws-sdk/types': 3.973.8
-      '@smithy/util-utf8': 2.3.0
-      tslib: 2.8.1
-
-  '@aws-sdk/types@3.973.8':
-    dependencies:
-      '@smithy/types': 4.14.1
-      tslib: 2.8.1
-
   '@axelar-network/axelar-cgp-solidity@4.5.0': {}
 
   '@axelar-network/axelar-cgp-solidity@6.4.0':
@@ -5030,24 +4983,6 @@ snapshots:
   '@sinclair/typebox@0.27.8': {}
 
   '@sindresorhus/is@5.6.0': {}
-
-  '@smithy/is-array-buffer@2.2.0':
-    dependencies:
-      tslib: 2.8.1
-
-  '@smithy/types@4.14.1':
-    dependencies:
-      tslib: 2.8.1
-
-  '@smithy/util-buffer-from@2.2.0':
-    dependencies:
-      '@smithy/is-array-buffer': 2.2.0
-      tslib: 2.8.1
-
-  '@smithy/util-utf8@2.3.0':
-    dependencies:
-      '@smithy/util-buffer-from': 2.2.0
-      tslib: 2.8.1
 
   '@socket.io/component-emitter@3.1.2': {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
 
   .:
     dependencies:
+      '@aws-crypto/sha256-js':
+        specifier: ^5.2.0
+        version: 5.2.0
       '@axelar-network/axelar-cgp-solidity':
         specifier: ^6.3.0
         version: 6.4.0
@@ -190,6 +193,17 @@ packages:
     peerDependencies:
       graphql: ^15.5.0 || ^16.0.0 || ^17.0.0
       typescript: ^5.0.0
+
+  '@aws-crypto/sha256-js@5.2.0':
+    resolution: {integrity: sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==}
+    engines: {node: '>=16.0.0'}
+
+  '@aws-crypto/util@5.2.0':
+    resolution: {integrity: sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==}
+
+  '@aws-sdk/types@3.973.8':
+    resolution: {integrity: sha512-gjlAdtHMbtR9X5iIhVUvbVcy55KnznpC6bkDUWW9z915bi0ckdUr5cjf16Kp6xq0bP5HBD2xzgbL9F9Quv5vUw==}
+    engines: {node: '>=20.0.0'}
 
   '@axelar-network/axelar-cgp-solidity@4.5.0':
     resolution: {integrity: sha512-4F4rmHei0cmzeUR7/mW4Bap5rc/KlPV2crD9HA7HTRfl15mVcN6/3z8p+pAm9We6bOrQplNW9KBZ3HJFP3C1Gw==}
@@ -1182,6 +1196,22 @@ packages:
   '@sindresorhus/is@5.6.0':
     resolution: {integrity: sha512-TV7t8GKYaJWsn00tFDqBw8+Uqmr8A0fRU1tvTQhyZzGv0sJCGRQL3JGMI3ucuKo3XIZdUP+Lx7/gh2t3lewy7g==}
     engines: {node: '>=14.16'}
+
+  '@smithy/is-array-buffer@2.2.0':
+    resolution: {integrity: sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==}
+    engines: {node: '>=14.0.0'}
+
+  '@smithy/types@4.14.1':
+    resolution: {integrity: sha512-59b5HtSVrVR/eYNei3BUj3DCPKD/G7EtDDe7OEJE7i7FtQFugYo6MxbotS8mVJkLNVf8gYaAlEBwwtJ9HzhWSg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-buffer-from@2.2.0':
+    resolution: {integrity: sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==}
+    engines: {node: '>=14.0.0'}
+
+  '@smithy/util-utf8@2.3.0':
+    resolution: {integrity: sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==}
+    engines: {node: '>=14.0.0'}
 
   '@socket.io/component-emitter@3.1.2':
     resolution: {integrity: sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA==}
@@ -3648,6 +3678,23 @@ snapshots:
       graphql: 16.12.0
       typescript: 5.9.3
 
+  '@aws-crypto/sha256-js@5.2.0':
+    dependencies:
+      '@aws-crypto/util': 5.2.0
+      '@aws-sdk/types': 3.973.8
+      tslib: 2.8.1
+
+  '@aws-crypto/util@5.2.0':
+    dependencies:
+      '@aws-sdk/types': 3.973.8
+      '@smithy/util-utf8': 2.3.0
+      tslib: 2.8.1
+
+  '@aws-sdk/types@3.973.8':
+    dependencies:
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
   '@axelar-network/axelar-cgp-solidity@4.5.0': {}
 
   '@axelar-network/axelar-cgp-solidity@6.4.0':
@@ -4983,6 +5030,24 @@ snapshots:
   '@sinclair/typebox@0.27.8': {}
 
   '@sindresorhus/is@5.6.0': {}
+
+  '@smithy/is-array-buffer@2.2.0':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/types@4.14.1':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/util-buffer-from@2.2.0':
+    dependencies:
+      '@smithy/is-array-buffer': 2.2.0
+      tslib: 2.8.1
+
+  '@smithy/util-utf8@2.3.0':
+    dependencies:
+      '@smithy/util-buffer-from': 2.2.0
+      tslib: 2.8.1
 
   '@socket.io/component-emitter@3.1.2': {}
 

--- a/src/libs/TransactionRecoveryApi/AxelarGMPRecoveryAPI.ts
+++ b/src/libs/TransactionRecoveryApi/AxelarGMPRecoveryAPI.ts
@@ -951,7 +951,7 @@ export class AxelarGMPRecoveryAPI extends AxelarRecoveryApi {
     if (!solanaKey) throw new Error("Cannot find Solana chain config");
 
     const solanaConfig = chains.chains[solanaKey];
-    const gasServiceProgramId = solanaConfig.config.contracts.GasService.address;
+    const gasServiceProgramId = solanaConfig.config.contracts.AxelarGasService.address;
 
     // Validate all Solana addresses
     validateSolanaAddress(sender, "sender address");

--- a/src/libs/TransactionRecoveryApi/AxelarGMPRecoveryAPI.ts
+++ b/src/libs/TransactionRecoveryApi/AxelarGMPRecoveryAPI.ts
@@ -1257,7 +1257,7 @@ export class AxelarGMPRecoveryAPI extends AxelarRecoveryApi {
 
     const instructionId = anchorInstructionDiscriminator("add_gas");
 
-    // Manual Borsh-like serialization to match Rust enum structure
+    // Manual Borsh serialization
     const data = concatU8([
       // instruction id
       instructionId,

--- a/src/libs/TransactionRecoveryApi/AxelarGMPRecoveryAPI.ts
+++ b/src/libs/TransactionRecoveryApi/AxelarGMPRecoveryAPI.ts
@@ -1212,8 +1212,8 @@ export class AxelarGMPRecoveryAPI extends AxelarRecoveryApi {
       );
     }
 
-    if (gasFeeAmountBigInt < BigInt(0)) {
-      throw new Error(`Invalid gasFeeAmount: must be non-negative, got ${gasFeeAmount}`);
+    if (gasFeeAmountBigInt <= BigInt(0)) {
+      throw new Error(`Invalid gasFeeAmount: must be positive, got ${gasFeeAmount}`);
     }
 
     // Validate the txHash portion of the messageId is a 64-byte base58 Solana signature

--- a/src/libs/TransactionRecoveryApi/AxelarGMPRecoveryAPI.ts
+++ b/src/libs/TransactionRecoveryApi/AxelarGMPRecoveryAPI.ts
@@ -1156,8 +1156,17 @@ export class AxelarGMPRecoveryAPI extends AxelarRecoveryApi {
 
     // Resolve programId + treasury (configPda):
     //   - If the caller supplied both, use them directly and skip the S3 lookup.
-    //   - Otherwise, look up the program ID from the chain config and derive the
-    //     treasury PDA locally from the program's seed.
+    //   - If the caller supplied exactly one, fail loudly — they're tightly
+    //     coupled (the treasury is a PDA of the program) and a partial override
+    //     is almost certainly a misconfiguration.
+    //   - Otherwise, look up the program ID from the chain config and derive
+    //     the treasury PDA locally from the program's seed.
+    if ((programId && !configPda) || (!programId && configPda)) {
+      throw new Error(
+        "addGasToSolanaChain: programId and configPda must be supplied together — " +
+          `got programId=${programId ?? "undefined"}, configPda=${configPda ?? "undefined"}`
+      );
+    }
     let gasServiceProgramIdPublicKey: PublicKey;
     let treasuryPda: PublicKey;
     if (programId && configPda) {

--- a/src/libs/TransactionRecoveryApi/AxelarGMPRecoveryAPI.ts
+++ b/src/libs/TransactionRecoveryApi/AxelarGMPRecoveryAPI.ts
@@ -1206,15 +1206,17 @@ export class AxelarGMPRecoveryAPI extends AxelarRecoveryApi {
 
     const [topLevelLogIndexStr, innerLogIndexStr] = logIndexParts;
 
-    // Reject any non-digit characters — parseInt would silently accept "3abc"
-    if (!/^\d+$/.test(topLevelLogIndexStr)) {
+    // The relayer parses these indices as u8, and Solana's 1232-byte tx size
+    // cap rules out anything larger in practice — enforce u8 here for parity.
+    // Digits-only first, since parseInt/Number would silently accept "3abc".
+    if (!/^\d+$/.test(topLevelLogIndexStr) || Number(topLevelLogIndexStr) > 255) {
       throw new Error(
-        `Invalid topLevelLogIndex in messageId: must be a non-negative integer, got "${topLevelLogIndexStr}"`
+        `Invalid topLevelLogIndex in messageId: must be an integer in [0, 255], got "${topLevelLogIndexStr}"`
       );
     }
-    if (!/^\d+$/.test(innerLogIndexStr)) {
+    if (!/^\d+$/.test(innerLogIndexStr) || Number(innerLogIndexStr) > 255) {
       throw new Error(
-        `Invalid innerLogIndex in messageId: must be a non-negative integer, got "${innerLogIndexStr}"`
+        `Invalid innerLogIndex in messageId: must be an integer in [0, 255], got "${innerLogIndexStr}"`
       );
     }
 

--- a/src/libs/TransactionRecoveryApi/AxelarGMPRecoveryAPI.ts
+++ b/src/libs/TransactionRecoveryApi/AxelarGMPRecoveryAPI.ts
@@ -1253,7 +1253,7 @@ export class AxelarGMPRecoveryAPI extends AxelarRecoveryApi {
       );
     }
 
-    const instructionId = await anchorInstructionDiscriminator("add_gas");
+    const instructionId = anchorInstructionDiscriminator("add_gas");
 
     // Manual Borsh-like serialization to match Rust enum structure
     const data = concatU8([

--- a/src/libs/TransactionRecoveryApi/AxelarGMPRecoveryAPI.ts
+++ b/src/libs/TransactionRecoveryApi/AxelarGMPRecoveryAPI.ts
@@ -57,7 +57,6 @@ import {
   anchorInstructionDiscriminator,
   encodeU64LE,
   encodeStringBorsh,
-  encodeU32LE,
 } from "./helpers";
 import { retry, throwIfInvalidChainIds } from "../../utils";
 import { EventResponse } from "@axelar-network/axelarjs-types/axelar/evm/v1beta1/query";
@@ -1140,16 +1139,8 @@ export class AxelarGMPRecoveryAPI extends AxelarRecoveryApi {
   public async addGasToSolanaChain(params: AddGasSolanaParams): Promise<SolanaTransaction> {
     const { messageId, gasFeeAmount, sender, refundAddress } = params;
 
-    const { callTx, status } = await this.queryTransactionStatus(messageId);
-
-    /**first check if transaction is already executed */
-    if (GMPErrorMap[status]) {
-      throw new Error(`GMP query error: ${GMPErrorMap[status]}`);
-    }
-    const srcChain: string = callTx.chain;
-
     const chains = await importS3Config(this.environment);
-    const solanaKey = Object.keys(chains.chains).find((chainName) => chainName == srcChain);
+    const solanaKey = Object.keys(chains.chains).find((chainName) => chainName.includes("solana"));
 
     if (!solanaKey) throw new Error("Cannot find Solana chain config");
 
@@ -1228,23 +1219,17 @@ export class AxelarGMPRecoveryAPI extends AxelarRecoveryApi {
       throw new Error(`Invalid gasFeeAmount: must be non-negative, got ${gasFeeAmount}`);
     }
 
-    // Decode Solana transaction hash from base58
-    let txHashBytes: Uint8Array;
+    // Validate the txHash portion of the messageId is a 64-byte base58 Solana signature
     try {
-      // Decode base58 Solana transaction signature to bytes
       const decoded = bs58.decode(txHash);
-
       if (decoded.length !== 64) {
         throw new Error(
           `Solana transaction signature must be 64 bytes when decoded, got ${decoded.length} bytes`
         );
       }
-
-      txHashBytes = decoded;
     } catch (error) {
-      // Preserve specific error messages (like length validation) but catch base58 decode errors
       if (error instanceof Error && error.message.includes("64 bytes")) {
-        throw error; // Re-throw length validation errors with original message
+        throw error;
       }
       throw new Error(
         `Failed to decode Solana transaction signature: ${txHash}. ${

--- a/src/libs/TransactionRecoveryApi/AxelarGMPRecoveryAPI.ts
+++ b/src/libs/TransactionRecoveryApi/AxelarGMPRecoveryAPI.ts
@@ -1250,7 +1250,7 @@ export class AxelarGMPRecoveryAPI extends AxelarRecoveryApi {
       encodeU64LE(gasFeeAmountBigInt),
       // refund_address
       refundAddressPublicKey.toBuffer(),
-    ]);
+    ] as unknown as Uint8Array[]);
 
     // Create the transaction instruction
     const instruction = new TransactionInstruction({

--- a/src/libs/TransactionRecoveryApi/AxelarGMPRecoveryAPI.ts
+++ b/src/libs/TransactionRecoveryApi/AxelarGMPRecoveryAPI.ts
@@ -198,6 +198,16 @@ export type AddGasSolanaParams = {
   gasFeeAmount: string; // Amount of SOL to add as gas (in lamports, will be converted to u64)
   sender: string; // Sender's Solana wallet address (base58 string) - must be signer
   refundAddress: string; // Refund address (base58 string) - goes in instruction data
+  /**
+   * @deprecated Optional. If both `programId` and `configPda` are supplied the SDK uses
+   * them directly and skips looking the gas-service program up from the S3 chain config.
+   */
+  programId?: string;
+  /**
+   * @deprecated Optional. See `programId` — both must be supplied together to override
+   * the S3 lookup.
+   */
+  configPda?: string;
 };
 
 export type SolanaInstruction = {
@@ -1138,28 +1148,36 @@ export class AxelarGMPRecoveryAPI extends AxelarRecoveryApi {
   }
 
   public async addGasToSolanaChain(params: AddGasSolanaParams): Promise<SolanaTransaction> {
-    const { messageId, gasFeeAmount, sender, refundAddress } = params;
+    const { messageId, gasFeeAmount, sender, refundAddress, programId, configPda } = params;
 
-    const chains = await importS3Config(this.environment);
-    const solanaKey = Object.keys(chains.chains).find((chainName) => chainName.includes("solana"));
-
-    if (!solanaKey) throw new Error("Cannot find Solana chain config");
-
-    const solanaConfig = chains.chains[solanaKey];
-    const gasServiceProgramId = solanaConfig.config.contracts.AxelarGasService.address;
-
-    // Validate all Solana addresses
+    // Validate the always-present addresses up front
     validateSolanaAddress(sender, "sender address");
-    const gasServiceProgramIdPublicKey = validateSolanaAddress(gasServiceProgramId, "program ID");
     const refundAddressPublicKey = validateSolanaAddress(refundAddress, "refund address");
 
-    // get the treasury pda
-    const treasuryPda = PublicKey.findProgramAddressSync(
-      [Buffer.from("gas-service")],
-      gasServiceProgramIdPublicKey
-    )[0];
+    // Resolve programId + treasury (configPda):
+    //   - If the caller supplied both, use them directly and skip the S3 lookup.
+    //   - Otherwise, look up the program ID from the chain config and derive the
+    //     treasury PDA locally from the program's seed.
+    let gasServiceProgramIdPublicKey: PublicKey;
+    let treasuryPda: PublicKey;
+    if (programId && configPda) {
+      gasServiceProgramIdPublicKey = validateSolanaAddress(programId, "program ID");
+      treasuryPda = validateSolanaAddress(configPda, "config PDA");
+    } else {
+      const chains = await importS3Config(this.environment);
+      const solanaKey = Object.keys(chains.chains).find((chainName) =>
+        chainName.includes("solana")
+      );
+      if (!solanaKey) throw new Error("Cannot find Solana chain config");
+      const resolvedProgramId = chains.chains[solanaKey].config.contracts.AxelarGasService.address;
+      gasServiceProgramIdPublicKey = validateSolanaAddress(resolvedProgramId, "program ID");
+      treasuryPda = PublicKey.findProgramAddressSync(
+        [Buffer.from("gas-service")],
+        gasServiceProgramIdPublicKey
+      )[0];
+    }
 
-    // get the event authority pda
+    // Event authority PDA is always derived from the program ID
     const gasServiceEventAuthority = PublicKey.findProgramAddressSync(
       [Buffer.from("__event_authority")],
       gasServiceProgramIdPublicKey
@@ -1278,7 +1296,7 @@ export class AxelarGMPRecoveryAPI extends AxelarRecoveryApi {
           isWritable: false,
         },
       ],
-      programId: new PublicKey(gasServiceProgramId),
+      programId: gasServiceProgramIdPublicKey,
       data: data,
     });
 

--- a/src/libs/TransactionRecoveryApi/AxelarGMPRecoveryAPI.ts
+++ b/src/libs/TransactionRecoveryApi/AxelarGMPRecoveryAPI.ts
@@ -57,6 +57,7 @@ import {
   anchorInstructionDiscriminator,
   encodeU64LE,
   encodeStringBorsh,
+  concatU8,
 } from "./helpers";
 import { retry, throwIfInvalidChainIds } from "../../utils";
 import { EventResponse } from "@axelar-network/axelarjs-types/axelar/evm/v1beta1/query";
@@ -1186,20 +1187,16 @@ export class AxelarGMPRecoveryAPI extends AxelarRecoveryApi {
     }
 
     const [topLevelLogIndexStr, innerLogIndexStr] = logIndexParts;
-    const topLevelLogIndex = parseInt(topLevelLogIndexStr);
-    const innerLogIndex = parseInt(innerLogIndexStr);
 
-    // Validate topLevelLogIndex
-    if (!Number.isInteger(topLevelLogIndex) || topLevelLogIndex < 0) {
+    // Reject any non-digit characters — parseInt would silently accept "3abc"
+    if (!/^\d+$/.test(topLevelLogIndexStr)) {
       throw new Error(
-        `Invalid topLevelLogIndex in messageId: must be a non-negative integer, got ${topLevelLogIndex}`
+        `Invalid topLevelLogIndex in messageId: must be a non-negative integer, got "${topLevelLogIndexStr}"`
       );
     }
-
-    // Validate innerLogIndex
-    if (!Number.isInteger(innerLogIndex) || innerLogIndex < 0) {
+    if (!/^\d+$/.test(innerLogIndexStr)) {
       throw new Error(
-        `Invalid innerLogIndex in messageId: must be a non-negative integer, got ${innerLogIndex}`
+        `Invalid innerLogIndex in messageId: must be a non-negative integer, got "${innerLogIndexStr}"`
       );
     }
 
@@ -1241,7 +1238,7 @@ export class AxelarGMPRecoveryAPI extends AxelarRecoveryApi {
     const instructionId = await anchorInstructionDiscriminator("add_gas");
 
     // Manual Borsh-like serialization to match Rust enum structure
-    const data = Buffer.concat([
+    const data = concatU8([
       // instruction id
       instructionId,
       // message_id
@@ -1250,7 +1247,7 @@ export class AxelarGMPRecoveryAPI extends AxelarRecoveryApi {
       encodeU64LE(gasFeeAmountBigInt),
       // refund_address
       refundAddressPublicKey.toBuffer(),
-    ] as unknown as Uint8Array[]);
+    ]);
 
     // Create the transaction instruction
     const instruction = new TransactionInstruction({

--- a/src/libs/TransactionRecoveryApi/helpers/solanaHelper.ts
+++ b/src/libs/TransactionRecoveryApi/helpers/solanaHelper.ts
@@ -1,3 +1,4 @@
+import { Sha256 } from "@aws-crypto/sha256-js";
 import { PublicKey } from "@solana/web3.js";
 
 /**
@@ -17,4 +18,51 @@ export function validateSolanaAddress(address: string, fieldName: string): Publi
       }`
     );
   }
+}
+
+/**
+ * Computes the Anchor instruction discriminator
+ * Equivalent to:
+ *   let preimage = format!("global:{}", method_name);
+ *   let discriminator = &sha256(preimage.as_bytes())[0..8];
+ *
+ * @param methodName Anchor instruction name
+ * @returns Promise<Buffer> exactly 8 bytes
+ */
+export async function anchorInstructionDiscriminator(methodName: string): Promise<Buffer> {
+  const preimage = `global:${methodName}`;
+  const encoder = new TextEncoder();
+  const sha = new Sha256();
+  sha.update(encoder.encode(preimage));
+
+  const digest = await sha.digest(); // returns Uint8Array (32 bytes)
+  return Buffer.from(digest.slice(0, 8)); // first 8 bytes = discriminator
+}
+
+// Borsh encoding helpers
+export function encodeVariantU8(index: number): Buffer {
+  if (index < 0 || index > 255) throw new Error("variant index out of range");
+  return Buffer.from([index]);
+}
+
+export function encodeU32LE(value: number): Buffer {
+  if (!Number.isInteger(value) || value < 0) {
+    throw new Error("encodeU32LE expects a non-negative integer");
+  }
+  const b = Buffer.alloc(4);
+  b.writeUInt32LE(value, 0);
+  return b;
+}
+
+export function encodeU64LE(value: bigint | number | string): Buffer {
+  const big = typeof value === "bigint" ? value : BigInt(value);
+  if (big < BigInt(0)) throw new Error("encodeU64LE expects non-negative");
+  const b = Buffer.alloc(8);
+  b.writeBigUInt64LE(big, 0);
+  return b;
+}
+
+export function encodeStringBorsh(value: string): Buffer {
+  const bytes = Buffer.from(value, "utf8");
+  return Buffer.concat([encodeU32LE(bytes.length), bytes]);
 }

--- a/src/libs/TransactionRecoveryApi/helpers/solanaHelper.ts
+++ b/src/libs/TransactionRecoveryApi/helpers/solanaHelper.ts
@@ -1,5 +1,5 @@
-import { Sha256 } from "@aws-crypto/sha256-js";
 import { PublicKey } from "@solana/web3.js";
+import { arrayify, sha256, toUtf8Bytes } from "ethers/lib/utils";
 
 /**
  * Helper function to validate Solana addresses using PublicKey
@@ -27,15 +27,10 @@ export function validateSolanaAddress(address: string, fieldName: string): Publi
  *   let discriminator = &sha256(preimage.as_bytes())[0..8];
  *
  * @param methodName Anchor instruction name
- * @returns Promise<Buffer> exactly 8 bytes
+ * @returns exactly 8 bytes
  */
-export async function anchorInstructionDiscriminator(methodName: string): Promise<Buffer> {
-  const preimage = `global:${methodName}`;
-  const encoder = new TextEncoder();
-  const sha = new Sha256();
-  sha.update(encoder.encode(preimage));
-
-  const digest = await sha.digest(); // returns Uint8Array (32 bytes)
+export function anchorInstructionDiscriminator(methodName: string): Buffer {
+  const digest = arrayify(sha256(toUtf8Bytes(`global:${methodName}`))); // 32 bytes
   return Buffer.from(digest.slice(0, 8)); // first 8 bytes = discriminator
 }
 

--- a/src/libs/TransactionRecoveryApi/helpers/solanaHelper.ts
+++ b/src/libs/TransactionRecoveryApi/helpers/solanaHelper.ts
@@ -64,5 +64,5 @@ export function encodeU64LE(value: bigint | number | string): Buffer {
 
 export function encodeStringBorsh(value: string): Buffer {
   const bytes = Buffer.from(value, "utf8");
-  return Buffer.concat([encodeU32LE(bytes.length), bytes]);
+  return Buffer.concat([encodeU32LE(bytes.length), bytes] as unknown as Uint8Array[]);
 }

--- a/src/libs/TransactionRecoveryApi/helpers/solanaHelper.ts
+++ b/src/libs/TransactionRecoveryApi/helpers/solanaHelper.ts
@@ -34,12 +34,6 @@ export function anchorInstructionDiscriminator(methodName: string): Buffer {
   return Buffer.from(digest.slice(0, 8)); // first 8 bytes = discriminator
 }
 
-// Borsh encoding helpers
-export function encodeVariantU8(index: number): Buffer {
-  if (index < 0 || index > 255) throw new Error("variant index out of range");
-  return Buffer.from([index]);
-}
-
 export function encodeU32LE(value: number): Buffer {
   if (!Number.isInteger(value) || value < 0) {
     throw new Error("encodeU32LE expects a non-negative integer");

--- a/src/libs/TransactionRecoveryApi/helpers/solanaHelper.ts
+++ b/src/libs/TransactionRecoveryApi/helpers/solanaHelper.ts
@@ -64,5 +64,12 @@ export function encodeU64LE(value: bigint | number | string): Buffer {
 
 export function encodeStringBorsh(value: string): Buffer {
   const bytes = Buffer.from(value, "utf8");
-  return Buffer.concat([encodeU32LE(bytes.length), bytes] as unknown as Uint8Array[]);
+  return concatU8([encodeU32LE(bytes.length), bytes]);
+}
+
+// Buffer.concat's typing is finicky across @types/node versions: a Buffer<ArrayBufferLike>[]
+// is not always accepted as Uint8Array<ArrayBufferLike>[] due to Symbol.dispose differences.
+// Centralize the cast here so call sites stay clean.
+export function concatU8(parts: ReadonlyArray<Buffer>): Buffer {
+  return Buffer.concat(parts as unknown as Uint8Array[]);
 }

--- a/src/libs/test/TransactionRecoveryAPI/AxelarGMPRecoveryAPI.spec.ts
+++ b/src/libs/test/TransactionRecoveryAPI/AxelarGMPRecoveryAPI.spec.ts
@@ -1346,7 +1346,7 @@ describe("AxelarGMPRecoveryAPI", () => {
             "solana-1234": {
               config: {
                 contracts: {
-                  GasService: {
+                  AxelarGasService: {
                     address: testGasServiceAddress,
                   },
                 },

--- a/src/libs/test/TransactionRecoveryAPI/AxelarGMPRecoveryAPI.spec.ts
+++ b/src/libs/test/TransactionRecoveryAPI/AxelarGMPRecoveryAPI.spec.ts
@@ -1413,7 +1413,7 @@ describe("AxelarGMPRecoveryAPI", () => {
     });
   });
 
-  describe.skip("addGas", () => {
+  describe("addGas", () => {
     let api: AxelarGMPRecoveryAPI;
     let contract: Contract;
     let userWallet: Wallet;

--- a/src/libs/test/TransactionRecoveryAPI/AxelarGMPRecoveryAPI.spec.ts
+++ b/src/libs/test/TransactionRecoveryAPI/AxelarGMPRecoveryAPI.spec.ts
@@ -50,8 +50,7 @@ import { Horizon } from "@stellar/stellar-sdk";
 import { SUI_TYPE_ARG } from "@mysten/sui/utils";
 import { Transaction } from "@mysten/sui/transactions";
 import * as chains from "../../../chains";
-import { STANDARD_FEE } from "../../AxelarSigningClient";
-import { coin, DirectSecp256k1HdWallet } from "@cosmjs/proto-signing";
+import { DirectSecp256k1HdWallet } from "@cosmjs/proto-signing";
 import {
   PublicKey as SolanaPublicKey,
   Keypair as SolanaKeypair,
@@ -1371,17 +1370,6 @@ describe("AxelarGMPRecoveryAPI", () => {
       SolanaTransaction.prototype.add = solanaAddInstructionCall;
 
       try {
-        // Mock the GMP api to get the message id
-        vitest.spyOn(api, "queryTransactionStatus").mockResolvedValueOnce({
-          status: "called",
-          callTx: {
-            chain: "solana-1234",
-            returnValues: {
-              destinationChain: "osmosis-7",
-            },
-          },
-        });
-
         // Mock the importS3Config to return a specific configuration
         vitest.spyOn(chains, "importS3Config").mockResolvedValue({
           chains: {


### PR DESCRIPTION
Changed the `addGasToSolanaChain` function in the SDK introduced in #368 for the new integration.

# Usage
```typescript
import { AxelarGMPRecoveryAPI, Environment } from '@axelar-network/axelarjs-sdk';
import { Connection } from "@solana/web3.js";

// Initialize SDK
const recoveryAPI = new AxelarGMPRecoveryAPI({
  environment: Environment.TESTNET, // or Environment.MAINNET
});

// Core function to add gas
async function addGasToSolana(params: {
  messageId: string;        // Format: "txHash-topLevelLogIndex.innerLogIndex" (e.g., "3SxSd9qgaxEvmhhXRiRCRrnfrbkYB1nAaZfeDyfZMXwcm1h99ZFHJMCkcH1fwtwXTsnPEfUQx7oSAPfZRuT1ZRsL-1.7")
  gasFeeAmount: string;     // Amount in lamports (1 SOL = 1e9 lamports).
  sender: string;           // Sender's Solana wallet address (must be signer and pays for gas)
  refundAddress: string;    // Refund address — receives any leftover gas
  wallet: any;              // Wallet adapter instance (Phantom, Solflare, etc.) exposing sendTransaction(tx, connection)
  connection: Connection;   // Solana connection — must point to the cluster the Axelar gas-service program is deployed on (devnet for testnet, mainnet-beta for mainnet)
}): Promise<string> {

  const { messageId, gasFeeAmount, sender, refundAddress, wallet, connection } = params;

  // Get transaction from SDK (returns a ready-to-use Transaction!)
  const transaction = await recoveryAPI.addGasToSolanaChain({
    messageId,      // Format: "txHash-topLevelLogIndex.innerLogIndex"
    gasFeeAmount,   // Amount in lamports
    sender,         // The wallet that pays for gas
    refundAddress,  // Where refunds are sent
  });

  // Send transaction directly - no need to manually create instruction!
  const signature = await wallet.sendTransaction(transaction, connection);

  // Wait for confirmation
  await connection.confirmTransaction(signature);

  return signature;
}
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Solana gas-topup transaction construction (instruction data layout, PDA/account set, and config resolution), which could break compatibility with the deployed gas-service program if mismatched. Adds stricter validation and a new S3-based lookup/derivation path that may fail for misconfigured chain config.
> 
> **Overview**
> Updates `addGasToSolanaChain` to match the new Solana gas-service integration: it now resolves the gas-service `programId` from S3 config by default (with an optional *deprecated* override requiring both `programId` + `configPda`), derives PDAs locally (treasury and `__event_authority`), and expands the instruction accounts to include these derived accounts.
> 
> Reworks Solana instruction encoding to use Anchor’s 8-byte discriminator plus Borsh-style serialization helpers (string + u64 + pubkey), tightens input validation (new `messageId` format `txHash-topLevel.inner`, u8-bounded indices, positive-only `gasFeeAmount`, and stricter signature decoding), and bumps the SDK version to `0.21.0` with a new unit test covering Solana instruction construction.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d803762887468871926663f5eb27dc45f0cd3b3b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->